### PR TITLE
⚡ Optimize O(N^2) array addition in BuildHosts.ps1

### DIFF
--- a/Scripts/Hostbuilder/BuildHosts.ps1
+++ b/Scripts/Hostbuilder/BuildHosts.ps1
@@ -126,14 +126,14 @@ $buildHostsButton.Add_Click({
             Invoke-WebRequest -Uri 'https://urlhaus.abuse.ch/downloads/hostfile' -UseBasicParsing -OutFile "$env:temp\haus.txt"
             #replace 127.0.0.1 with 0.0.0.0
             $content = Get-Content "$env:temp\haus.txt"
-            $fixed = @()
-            foreach ($line in $content) {
+            $fixed = foreach ($line in $content) {
+
                 if ($line -like '127.0.0.1*') {
-                    $newLine = $line -replace '127.0.0.1' , '0.0.0.0'
-                    $fixed += $newLine
+                    $line -replace '127.0.0.1' , '0.0.0.0'
+
                 }
                 else {
-                    $fixed += $line
+                    $line
                 }
             }
             set-content "$env:temp\fixedHaus.txt" -Value $fixed -Force


### PR DESCRIPTION
💡 **What:**
Refactored the array addition logic inside `Scripts/Hostbuilder/BuildHosts.ps1` around line 130 to capture the output of the `foreach` loop directly into a variable instead of appending to an array using `+=`.

🎯 **Why:**
In PowerShell, arrays are immutable. Using the `+=` operator inside a loop forces PowerShell to allocate a brand new array and copy all existing elements plus the new one on every single iteration. This leads to an `O(N^2)` time complexity for array building. Hosts files can potentially contain thousands or millions of lines, making the original `+=` operation a significant performance bottleneck.

By using the `$fixed = foreach ($line in $content) { ... }` construct, PowerShell optimizes the collection of the loop output by utilizing a dynamically resizing list (like `ArrayList` or `List<T>`) internally, which brings the complexity back down to `O(N)`.

📊 **Measured Improvement:**
Since the current environment does not have `pwsh` installed (it is a Linux-based agent environment with no PowerShell infrastructure), I was unable to dynamically execute and benchmark the script to demonstrate the exact time saved. 

However, avoiding `+=` in large loops is a universally known and documented PowerShell performance anti-pattern. Given that host files are generally large, converting an O(N^2) operation to O(N) guarantees a dramatic performance improvement in execution time and memory allocations for any realistically-sized hosts file.

---
*PR created automatically by Jules for task [13447644155681232549](https://jules.google.com/task/13447644155681232549) started by @Ven0m0*