### PR TITLE
Fix Windows compatibility for BleachBit coding cleaner

### DIFF
--- a/user/.dotfiles/config/bleachbit/cleaners/coding.xml
+++ b/user/.dotfiles/config/bleachbit/cleaners/coding.xml
@@ -22,8 +22,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="coding" os="linux">
-  <!-- FIXME: Does it work under Windows? -->
+<cleaner id="coding">
   <label>Coding caches</label>
   <description>Clean development tools cache</description>
   <option id="gradle">


### PR DESCRIPTION
- Removed the `os="linux"` constraint from the `<cleaner>` tag in `coding.xml`, making it active on all platforms, including Windows where `~/` natively resolves to `%USERPROFILE%`.
- Removed the FIXME comment regarding Windows compatibility.

---
*PR created automatically by Jules for task [926913435740475494](https://jules.google.com/task/926913435740475494) started by @Ven0m0*