### PR TITLE
⚡ Optimize registry query in NvidiaAutoinstall.ps1

### DIFF
--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -732,10 +732,16 @@ if (!(Check-Internet)) {
 
 
     #adding saturation reg key paths to an array
-    $paths = @()
-    for ($i = 0; $i -lt $dList.Length; $i++) {
-        $paths += Get-ChildItem -Path 'registry::HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\nvlddmkm\State\DisplayDatabase\' | Where-Object { $_.Name -like "*$($dList[$i])*" } | Select-Object -First 1
-
+    $paths = if ($null -ne $dList -and $dList.Length -gt 0) {
+        $allDisplayDbKeys = @(Get-ChildItem -Path 'registry::HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\nvlddmkm\State\DisplayDatabase\')
+        foreach ($deviceId in $dList) {
+            $match = $allDisplayDbKeys | Where-Object { $_.Name -like "*$deviceId*" } | Select-Object -First 1
+            if ($null -ne $match) {
+                $match
+            }
+        }
+    } else {
+        @()
     }
  
   


### PR DESCRIPTION
💡 **What:** 
Replaced an N+1 registry query inside a `for` loop in `NvidiaAutoinstall.ps1` with a single `Get-ChildItem` query that fetches all the registry keys beforehand. The loop now iterates over the cached results locally using `Where-Object`. Additionally, replaced the slow array concatenation (`+=`) with a block assignment.

🎯 **Why:** 
The original code iteratively queried the registry for each display device ID which triggers unnecessary disk/registry I/O and creates an N+1 performance bottleneck. Furthermore, `+=` array concatenation creates a new array in memory each time, leading to O(N^2) complexity. This optimization fixes both issues, significantly speeding up the monitor setup phase of the autoinstall script.

📊 **Measured Improvement:** 
*Measurement was not possible locally.* As noted in the memory context, the current environment is Linux-based and does not have PowerShell (`pwsh`) installed, which prevents local execution or benchmarking of `.ps1` scripts. However, reducing N registry I/O calls to 1 call and eliminating O(N^2) array allocations is an undisputed performance improvement in PowerShell scripting.

---
*PR created automatically by Jules for task [4254730844286857494](https://jules.google.com/task/4254730844286857494) started by @Ven0m0*