### PR TITLE
🔒 [security] Fix insecure executable downloads over HTTP

### DIFF
--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -175,7 +175,7 @@ if (-not (Get-AppPackage -name "Microsoft.DesktopAppInstaller")) {
   @'
 $releases_url = "https://api.github.com/repos/microsoft/winget-cli/releases/latest"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Register-PackageSource -Name Nuget -Location "http://www.nuget.org/api/v2" -ProviderName Nuget -Trusted
+Register-PackageSource -Name Nuget -Location "https://www.nuget.org/api/v2" -ProviderName Nuget -Trusted
 Install-Package Microsoft.UI.Xaml -RequiredVersion 2.7.1
 $releases = Invoke-RestMethod -uri $releases_url
 $latestRelease = $releases.assets | Where { $_.browser_download_url.EndsWith('msixbundle') } | Select-Object -First 1
@@ -306,8 +306,8 @@ sudo New-Item -ItemType SymbolicLink -Path "$(Split-Path -Path (Get-Command busy
 sudo New-Item -ItemType SymbolicLink -Path "$(Split-Path -Path (Get-Command tdmgr*.exe).Source)\tdmgr.exe" -Target (Get-Command tdmgr*.exe).Source
 
 # Custom packages
-Install-CustomApp -URL "http://www.chrysocome.net/downloads/0d23e6a31f1d37850fc2040eec98e9f9/rawwritewin-0.7.zip" -Folder "RawWrite"
-Install-CustomApp -URL "http://www.handshake.de/user/chmaas/delphi/download/xvi32.zip" -Folder "XVI32"
+Install-CustomApp -URL "https://www.chrysocome.net/downloads/0d23e6a31f1d37850fc2040eec98e9f9/rawwritewin-0.7.zip" -Folder "RawWrite"
+Install-CustomApp -URL "https://www.handshake.de/user/chmaas/delphi/download/xvi32.zip" -Folder "XVI32"
 Install-CustomApp -URL "https://code.kliu.org/misc/winisoutils/eicfg_removal_utility.zip"  -Folder "ei.cfg-removal-utility"
 Install-CustomPackage -URL "https://downloads.sourceforge.net/project/catacombae/HFSExplorer/2021.10.9/hfsexplorer-2021.10.9-setup.exe"
 New-Item -Path "$Env:UserProfile\bin\RipMe" -ItemType Directory -ErrorAction Ignore | Out-Null

--- a/setup.ps1
+++ b/setup.ps1
@@ -245,7 +245,7 @@ winget install Microsoft.Edit -h 2>&1 | Out-Null
 winget install yadm -h 2>&1 | Out-Null
 
 # GMK Driver
-Invoke-RestMethod http://offset-power.net/GMKDriver/setup.exe -OutFile "$env:TEMP\gmk.exe"
+Invoke-RestMethod https://offset-power.net/GMKDriver/setup.exe -OutFile "$env:TEMP\gmk.exe"
 & "$env:TEMP\gmk.exe" 2>&1 | Out-Null
 
 # HEVC/HEIF Extensions
@@ -258,7 +258,7 @@ Get-AppXPackage -AllUsers *Microsoft.HEIFImageExtension* | ForEach-Object {
 
 # Scoop
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-Invoke-RestMethod get.scoop.sh -OutFile "$env:TEMP\install.ps1"
+Invoke-RestMethod https://get.scoop.sh -OutFile "$env:TEMP\install.ps1"
 & "$env:TEMP\install.ps1" -NoProxy 2>&1 | Out-Null
 if (Get-Command scoop -ErrorAction SilentlyContinue) { scoop bucket add extras 2>&1 | Out-Null }
 

--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -240,7 +240,7 @@ function mkcd {
 }
 
 # Network Utilities
-function Get-PubIP { (Invoke-WebRequest http://ifconfig.me/ip).Content }
+function Get-PubIP { (Invoke-WebRequest https://ifconfig.me/ip).Content }
 
 # Open WinUtil full-release
 function winutil { irm https://christitus.com/win | iex }


### PR DESCRIPTION
🎯 **What:** Fixed insecure executable and script downloads by switching from HTTP to HTTPS in `setup.ps1`, `Scripts/shell-setup.ps1`, and the user's PowerShell profile.

⚠️ **Risk:** Downloading executables (`.exe`) or scripts (`.ps1`) over insecure HTTP makes users vulnerable to Man-in-the-Middle (MitM) attacks. An attacker could intercept the connection and replace the legitimate software with malicious code, which would then be executed with the user's privileges (often Administrator in the context of these setup scripts).

🛡️ **Solution:** Updated all identified insecure URLs to use HTTPS. Verified that the target domains support HTTPS. This ensures the integrity and authenticity of the downloaded files during transport.

---
*PR created automatically by Jules for task [12088075602686674138](https://jules.google.com/task/12088075602686674138) started by @Ven0m0*