### PR TITLE
docs: Add Kilo Code skill guides and opencode command templates

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,13 @@
+# .ignore — ripgrep ignore file consumed by opencode's grep/glob/list tools
+# .gitignore already excludes build outputs, OS noise, and editor dirs comprehensively.
+# This file only un-ignores paths that opencode SHOULD discover despite being gitignored,
+# or suppresses paths not covered by .gitignore that add no search value.
+
+# ─── Un-ignore: files gitignored but useful for AI context ───────────────────
+# (none currently — .gitignore does not exclude any repo source files that
+#  opencode needs to discover. Add entries here with ! if that changes.)
+
+# ─── Additional suppression: CI artifacts not in .gitignore ──────────────────
+results.sarif
+github-step-summary.md
+megalinter-reports/

--- a/.kilocode/rules/architecture.md
+++ b/.kilocode/rules/architecture.md
@@ -1,0 +1,54 @@
+# Architecture Rules
+
+## Module boundary: Common.ps1 is the only shared library
+
+- `Scripts/Common.ps1` is the single shared utility module. All scripts dot-source it: `. "$PSScriptRoot\Common.ps1"`
+- If logic is used in two or more scripts, it MUST be extracted to `Common.ps1`, not copy-pasted
+- Do not create additional `*.psm1` modules unless there is a compelling reason (e.g., the `minify-ps1/` submodule is pre-existing — don't add peers)
+
+## Where new files go
+
+| Artifact | Location |
+|---|---|
+| New PowerShell scripts | `Scripts/` (top level, `lowercase-with-dashes.ps1`) |
+| Shared utility functions | `Scripts/Common.ps1` |
+| Registry `.reg` files | `Scripts/reg/` |
+| User config files | `user/.dotfiles/config/<app>/` |
+| PowerShell profile | `user/.dotfiles/config/powershell/profile.ps1` |
+| Windows Terminal config | `user/.dotfiles/config/windows-terminal/` |
+| Game configs | `user/.dotfiles/config/games/<game-name>/` |
+| GitHub Actions workflows | `.github/workflows/` |
+| Copilot instructions | `.github/instructions/` |
+
+## Deprecated paths — never use
+
+- `.config/` at repo root — deprecated, use `user/.dotfiles/config/` instead
+- Any config file at repo root that should be under `user/.dotfiles/config/`
+
+## Script structure requirement
+
+Every script in `Scripts/` that modifies system state must follow the interactive menu loop pattern (not a one-shot script):
+
+```
+header (#Requires, dot-source Common.ps1)
+→ Request-AdminElevation
+→ Initialize-ConsoleUI
+→ define functions (Enable-X, Disable-X, Show-Status)
+→ while ($true) { Show-Menu → Get-MenuChoice → switch }
+```
+
+One-shot scripts (no menu) are only acceptable for utilities called from other scripts or CI.
+
+## Import order
+
+1. `#Requires` directives
+2. `. "$PSScriptRoot\Common.ps1"` dot-source
+3. Function definitions
+4. Top-level execution (elevation check, menu loop)
+
+## What NOT to touch
+
+- `Scripts/minify-ps1/` — PSMinifier module, managed by CI and Renovate. Don't modify manually.
+- `Scripts/win-iso/` — standalone ISO tooling with its own conventions
+- `.github/workflows/*.yml` — CI config; only change when adding a new workflow or updating action versions (use Renovate/Dependabot)
+- `renovate.json` — dependency update config managed by Renovate bot

--- a/.kilocode/rules/code-style.md
+++ b/.kilocode/rules/code-style.md
@@ -1,0 +1,48 @@
+# Code Style Rules
+
+## PowerShell (`.ps1`, `.psm1`) — enforced by PSScriptAnalyzer CI
+
+- **Brace style**: OTBS — opening `{` on the same line as the keyword. `function Foo {` not `function Foo\n{`
+- **Indent**: 2 spaces. No tabs. `.editorconfig` sets `indent_style = space`, `indent_size = 2` for `*.ps1`/`*.psm1`
+- **Line length**: 120 chars max (`.editorconfig` `max_line_length = 120`)
+- **Line endings**: CRLF. `.editorconfig` `end_of_line = crlf` for `*.ps1`/`*.psm1`
+- **Encoding**: UTF-8 with BOM for PowerShell files
+- **Operators**: spaces around all binary operators — `$x = $a + $b`, `-eq`, `-ne`, `-lt`, `-gt`
+- **Pipes**: space before and after `|` — `Get-Process | Where-Object { $_ -eq 'foo' }`
+- **Trailing whitespace**: trimmed (except `.md` files)
+
+## File naming
+
+| Type | Convention | Example |
+|---|---|---|
+| PowerShell scripts | `lowercase-with-dashes.ps1` | `gaming-display.ps1` |
+| Batch files | `lowercase-with-dashes.cmd` | `allow-scripts.cmd` |
+| Important docs | `UPPERCASE.md` | `AGENTS.md`, `README.md` |
+| Config files | Follow application convention | `settings.json` |
+| Registry files | `lowercase-with-dashes.reg` | — |
+
+## Comment-based help (required on all public functions)
+
+```powershell
+<#
+.SYNOPSIS
+    One-line description (required).
+.DESCRIPTION
+    Extended description.
+.PARAMETER ParamName
+    What this parameter does.
+.EXAMPLE
+    Verb-Noun -ParamName "value"
+#>
+```
+
+## Banned PSScriptAnalyzer rules (CI will fail)
+
+- `PSAvoidGlobalAliases` — no `ls`, `cd`, `rm` etc.; use `Get-ChildItem`, `Set-Location`, `Remove-Item`
+- `PSAvoidUsingConvertToSecureStringWithPlainText` — never store plaintext secrets this way
+- `PSAvoidUsingInvokeExpression` with variable input — injection risk
+
+## Markdown
+
+- Trailing whitespace allowed (`.editorconfig` `trim_trailing_whitespace = false` for `*.md`)
+- `UPPERCASE.md` naming for important docs; `lowercase.md` for everything else

--- a/.kilocode/rules/security.md
+++ b/.kilocode/rules/security.md
@@ -1,0 +1,39 @@
+# Security Rules
+
+## Files you MUST NOT read, write, or stage
+
+These files contain credentials or personal data. Never open, display, or commit them:
+
+- `.gitconfig` / `.gitconfig.local` — may contain real email/identity
+- `.github-personal-access-token` — OAuth token
+- `user/.dotfiles/config/powershell/local.ps1` — machine-specific secrets/paths
+- `.ssh/*` except `.ssh/config` — private keys
+- `.gnupg/*` — GPG keyring
+- `.config/gh/hosts.yml` — GitHub CLI token
+- Any file matching `*.env`, `token`, `*credentials*`, `*secret*`, `*.key`, `*.pem`, `*.pfx`
+
+## Injection prevention
+
+- **Never** use `Invoke-Expression` (or its alias `iex`) with any variable input. Only acceptable with a literal string constant.
+- **Never** construct registry paths, file paths, or command strings by concatenating unvalidated user input.
+- **Never** use `$ErrorActionPreference = "SilentlyContinue"` at script scope — it silently swallows errors that indicate security failures (e.g., permission denials).
+
+## Script safety requirements
+
+Every script that modifies system state MUST:
+1. Confirm admin rights via `Request-AdminElevation` from `Common.ps1`
+2. Display what it will do before doing it
+3. Require explicit user confirmation (menu selection) before destructive operations
+4. Provide a "Restore defaults" option for any registry or config change
+
+## Registry safety
+
+- Never delete a registry key (`Remove-Item -Recurse` on a registry path) — only delete individual values via `Remove-RegistryValue`
+- Writes to `HKLM\SYSTEM\CurrentControlSet\Services\*` require an explicit warning comment explaining the reboot requirement and failure risk
+
+## Hardcoded paths are banned
+
+Using `C:\Users\<username>\` or any absolute personal path is a security and portability violation. Always use:
+- `$HOME` for user home
+- `$PSScriptRoot` for script-relative paths
+- `$env:WINDIR`, `$env:PROGRAMFILES`, `$env:APPDATA` for system paths

--- a/.kilocode/rules/testing.md
+++ b/.kilocode/rules/testing.md
@@ -1,0 +1,48 @@
+# Testing Rules
+
+## Primary test tool: PSScriptAnalyzer
+
+There is no automated unit test suite (no Pester tests for most scripts). The primary quality gate is static analysis via PSScriptAnalyzer, which runs in CI on every push and PR.
+
+**Local lint check (run before every commit):**
+```powershell
+# Single file
+Invoke-ScriptAnalyzer -Path Scripts/your-script.ps1
+
+# All scripts
+Invoke-ScriptAnalyzer -Path Scripts/ -Recurse
+
+# Specific rules enforced by CI
+Invoke-ScriptAnalyzer -Path Scripts/ -Recurse `
+  -IncludeRule "PSAvoidGlobalAliases","PSAvoidUsingConvertToSecureStringWithPlainText"
+```
+
+## Manual testing protocol
+
+Since scripts interact with live Windows registry and system settings, testing requires:
+
+1. **Syntax check first**: `Invoke-ScriptAnalyzer` must return zero errors
+2. **Run as admin**: `PowerShell.exe -ExecutionPolicy Bypass -File Scripts/your-script.ps1`
+3. **Registry changes**: capture baseline with `Get-ItemProperty -Path "HKLM\..."` before running, verify the expected key/value after
+4. **Restore verification**: always test the "Restore defaults" menu option — confirm it reverts to the baseline captured in step 3
+
+## Existing test file
+
+`Scripts/New-QueryString.Tests.ps1` — Pester test for the `New-QueryString` utility. If adding Pester tests, follow this file's pattern.
+
+## CI gates (must not be broken)
+
+| Workflow | Trigger | What it checks |
+|---|---|---|
+| `PSScriptAnalyzer` | push/PR to `main` | `PSAvoidGlobalAliases`, `PSAvoidUsingConvertToSecureStringWithPlainText` across entire repo |
+| `PSMinifier` | push/PR touching `*.ps1`/`*.psm1` | Minification succeeds; auto-commits minified output on push to `main` |
+
+## No mocking policy
+
+Scripts that modify registry or system settings must be tested against a real Windows system — do not attempt to mock registry calls in Pester. The overhead of mocking `Set-ItemProperty` (via `Common.ps1`) is not worth the false confidence it provides for system-level scripts.
+
+## Test coverage expectation
+
+- All new `Common.ps1` utility functions: add a corresponding Pester test in `Scripts/New-QueryString.Tests.ps1` or a new `*.Tests.ps1` sibling
+- Scripts with complex branching logic (Enable/Disable paths): manually test each branch
+- Registry scripts: verify both the "apply" and "restore defaults" paths

--- a/.kilocode/skills/powershell-windows/SKILL.md
+++ b/.kilocode/skills/powershell-windows/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: powershell-windows
+description: PowerShell scripting conventions for this Windows dotfiles repo — OTBS style, Common.ps1 usage, admin elevation, error handling, and comment-based help patterns used in Scripts/*.ps1
+---
+
+# PowerShell Windows Scripting
+
+## Mandatory header for every script in Scripts/
+
+```powershell
+#Requires -RunAsAdministrator
+. "$PSScriptRoot\Common.ps1"
+```
+
+## Top-level execution block
+
+```powershell
+Request-AdminElevation
+Initialize-ConsoleUI -Title "Script Name (Administrator)"
+```
+
+## Function structure
+
+```powershell
+<#
+.SYNOPSIS
+    One-line description.
+.DESCRIPTION
+    Extended description.
+.PARAMETER Name
+    What this parameter controls.
+.EXAMPLE
+    Enable-Feature -Name "value"
+#>
+function Enable-Feature {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Name
+  )
+
+  Set-StrictMode -Version Latest
+  $ErrorActionPreference = "Stop"
+
+  # implementation
+}
+```
+
+## Style rules (enforced by PSScriptAnalyzer CI)
+
+- OTBS: `{` on same line, never on a new line
+- 2-space indent — no tabs
+- Spaces around operators: `$x = $a + $b`, `$list | Where-Object { $_ -eq $x }`
+- Max 120 chars per line
+- File names: `lowercase-with-dashes.ps1`
+
+## Common.ps1 API — use these, do not re-implement
+
+| Task | Function |
+|------|----------|
+| Admin check | `Request-AdminElevation` |
+| Console setup | `Initialize-ConsoleUI -Title "..."` |
+| Show menu | `Show-Menu -Title "..." -Options @(...)` |
+| Get choice | `Get-MenuChoice -Min 1 -Max N` |
+| Write registry | `Set-RegistryValue -Path -Name -Type -Data` |
+| Delete registry value | `Remove-RegistryValue -Path -Name` |
+| NVIDIA GPU paths | `Get-NvidiaGpuRegistryPaths` |
+| Download file | `Get-FileFromWeb -URL -File` |
+| Clear directory | `Clear-DirectorySafe -Path` |
+| Parse Steam VDF | `ConvertFrom-VDF -Content` |
+| Serialize Steam VDF | `ConvertTo-VDF -Data` |
+
+## Interactive menu loop pattern
+
+```powershell
+while ($true) {
+  Show-Menu -Title "Feature Menu" -Options @("Enable", "Disable", "Status", "Exit")
+  $choice = Get-MenuChoice -Min 1 -Max 4
+
+  switch ($choice) {
+    1 { Enable-Feature }
+    2 { Disable-Feature }
+    3 { Show-Status }
+    4 { exit }
+  }
+
+  Read-Host "`nPress Enter to continue"
+}
+```
+
+## Banned patterns
+
+- `Invoke-Expression` with variable input → injection risk
+- `$ErrorActionPreference = "SilentlyContinue"` at global scope → silently hides failures
+- Hardcoded paths like `C:\Users\username\` → use `$HOME` or `$PSScriptRoot`
+- Raw `Set-ItemProperty` for registry → use `Set-RegistryValue` from Common.ps1
+- Duplicating logic that's already in Common.ps1

--- a/.kilocode/skills/registry-tweaks/SKILL.md
+++ b/.kilocode/skills/registry-tweaks/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: registry-tweaks
+description: Windows registry modification patterns for this repo — correct use of Common.ps1 Set-RegistryValue/Remove-RegistryValue, HKLM vs HKCU selection, REG_DWORD/REG_SZ/REG_BINARY types, and reversibility requirements
+---
+
+# Registry Tweaks
+
+## Correct write pattern
+
+```powershell
+# Always via Common.ps1 — never raw Set-ItemProperty
+Set-RegistryValue -Path "HKLM\SOFTWARE\Policies\Microsoft\Windows\..." `
+                  -Name "FeatureName" `
+                  -Type "REG_DWORD" `
+                  -Data "1"
+```
+
+## Correct delete pattern
+
+```powershell
+Remove-RegistryValue -Path "HKLM\SOFTWARE\..." -Name "FeatureName"
+```
+
+## HKLM vs HKCU
+
+| Use `HKLM` | Use `HKCU` |
+|---|---|
+| System-wide settings (all users) | Per-user settings |
+| GPU/display driver tweaks | User-specific shell/UI prefs |
+| Network stack settings | Profile/appearance settings |
+
+`HKLM` requires admin (`#Requires -RunAsAdministrator`). `HKCU` does not, but scripts still request elevation for consistency.
+
+## Value types
+
+| Type | Use case | Valid data |
+|---|---|---|
+| `REG_DWORD` | Flags, integers | 0–0xFFFFFFFF decimal or `"0x..."` hex |
+| `REG_SZ` | Plain strings | Any string (no `%VAR%` expansion) |
+| `REG_EXPAND_SZ` | Paths with env vars | Strings containing `%WINDIR%` etc. |
+| `REG_BINARY` | Raw byte data | Hex string pairs e.g. `"00,01,02"` |
+
+## Reversibility rule
+
+Every script that writes registry values MUST:
+1. Document the original/default value in a comment
+2. Offer a "Restore defaults" menu option that calls `Set-RegistryValue` with the original value
+3. Never delete a key (only values) unless absolutely required
+
+## NVIDIA GPU paths helper
+
+```powershell
+$gpuPaths = Get-NvidiaGpuRegistryPaths
+foreach ($path in $gpuPaths) {
+  Set-RegistryValue -Path $path -Name "..." -Type "REG_DWORD" -Data "1"
+}
+```
+
+## High-risk paths — always comment with justification
+
+- `HKLM\SYSTEM\CurrentControlSet\Services\*` — driver/service config, reboot required, can brick system
+- `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\*` — OS identity/boot config
+- `HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\*` — GPU driver config
+
+## .reg file format
+
+Files in `Scripts/reg/` follow standard `.reg` format. Always include a restore/undo `.reg` alongside any change `.reg`.

--- a/.kilocode/skills/yadm-dotfiles/SKILL.md
+++ b/.kilocode/skills/yadm-dotfiles/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: yadm-dotfiles
+description: yadm dotfile management workflow for this repo — tracking files under $HOME, bootstrap process, config file locations, and the distinction between yadm (dotfiles) and git (this Scripts repo)
+---
+
+# yadm Dotfiles Workflow
+
+## What yadm is
+
+yadm is a git wrapper that treats `$HOME` as the working tree. It tracks dotfiles (PowerShell profile, terminal config, etc.) without symlinks.
+
+## Key distinction
+
+| yadm | git |
+|---|---|
+| Manages dotfiles at `$HOME` | Manages this Scripts/config repo at `~/Win` |
+| `yadm add ~/.config/...` | `git add Scripts/new-script.ps1` |
+| `yadm push` to sync dotfiles | `git push` for this repo |
+
+## Dotfile locations
+
+All active configs live in `user/.dotfiles/config/` — NOT `.config/` (deprecated):
+
+| Config | Path |
+|---|---|
+| PowerShell profile | `user/.dotfiles/config/powershell/profile.ps1` |
+| Machine-local overrides | `user/.dotfiles/config/powershell/local.ps1` (gitignored) |
+| Windows Terminal | `user/.dotfiles/config/windows-terminal/settings.json` |
+| Game configs | `user/.dotfiles/config/games/<game>/` |
+| BleachBit cleaners | `user/.dotfiles/config/bleachbit/cleaners/` |
+
+## Bootstrap (new machine)
+
+```powershell
+winget install yadm
+yadm clone https://github.com/Ven0m0/Win.git
+pwsh $HOME\.yadm\bootstrap
+```
+
+Bootstrap sets up: PowerShell profile symlinks, Windows Terminal config, git defaults, dev tools via winget, Scripts dir added to PATH.
+
+## Common yadm commands
+
+```powershell
+yadm status           # what's changed in tracked dotfiles
+yadm diff             # see changes
+yadm add <file>       # track a new dotfile
+yadm commit -m "..."
+yadm push             # sync to remote
+yadm ls-files         # list all tracked dotfiles
+```
+
+## Never track
+
+- `user/.dotfiles/config/powershell/local.ps1` — machine-specific, gitignored
+- `.gitconfig` / `.gitconfig.local` — contain personal email
+- `.ssh/` directory (`.ssh/config` is OK)
+- Any `.env` file or token file

--- a/.kilocodeignore
+++ b/.kilocodeignore
@@ -1,0 +1,83 @@
+# .kilocodeignore — paths Kilo Code MUST NOT access via any tool
+# Syntax: gitignore patterns. Use ! to un-ignore.
+
+# ─── Secrets & Credentials ──────────────────────────────────────────────────
+.gitconfig
+.gitconfig.local
+.github-personal-access-token
+*.env
+*.env.*
+token
+*credentials*
+*secret*
+*.key
+*.pem
+*.pfx
+*.crt
+*.p12
+.ssh/*
+!.ssh/config
+.gnupg/
+.config/gh/hosts.yml
+user/.dotfiles/config/powershell/local.ps1
+
+# ─── Build Output & Generated Files ─────────────────────────────────────────
+build/
+dist/
+target/
+[Dd]ebug/
+[Rr]elease/
+[Oo]bj/
+[Oo]ut/
+artifacts/
+*.min.ps1
+*.minified.ps1
+
+# ─── Lock Files (no AI value) ────────────────────────────────────────────────
+*.lock
+*.lck
+/package-lock.json
+
+# ─── Large Binary / Cache Dirs ───────────────────────────────────────────────
+.cache/
+.nv/ComputeCache/
+node_modules/
+__pycache__/
+.ruff_cache/
+.cargo/
+.rustup/
+
+# ─── OS / Editor Noise ───────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+Desktop.ini
+*.bak
+*.tmp
+*.log
+*.log.*
+.vs/
+.idea/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# ─── User XDG Dirs (not repo content) ────────────────────────────────────────
+Desktop/
+Documents/
+Downloads/
+Music/
+Pictures/
+Videos/
+
+# ─── CI Reports ──────────────────────────────────────────────────────────────
+megalinter-reports/
+results.sarif
+github-step-summary.md
+
+# execute_command restriction
+# The following shell commands MUST NOT be run against blocked paths above,
+# as execute_command bypasses read_file restrictions:
+#   cat, head, tail, sed, awk, less, more, grep, rg, strings
+# Never: cat .gitconfig | ..., grep -r token .ssh/, etc.

--- a/.opencode/commands/analyze-registry.md
+++ b/.opencode/commands/analyze-registry.md
@@ -1,0 +1,33 @@
+---
+description: Audit registry changes in a script or .reg file for correctness and reversibility
+agent: code
+---
+
+Audit the registry operations in: `$ARGUMENTS`
+
+@$ARGUMENTS
+
+For each registry key/value operation, verify:
+
+1. **Path correctness**
+   - Confirm `HKLM` vs `HKCU` is appropriate (system-wide vs per-user)
+   - Flag any path that targets an undocumented or unofficial key
+
+2. **Value type accuracy**
+   - `REG_DWORD` must be a 32-bit integer (0–0xFFFFFFFF)
+   - `REG_SZ` must be a plain string; use `REG_EXPAND_SZ` for paths with `%ENV%` vars
+   - `REG_BINARY` values must be valid hex pairs
+
+3. **Reversibility**
+   - Every SET must have a corresponding documented restore value
+   - Scripts must include a "Restore defaults" menu option
+
+4. **Safety**
+   - Flag any write to `HKLM\SYSTEM\CurrentControlSet\Services` — requires reboot and can brick the system
+   - Flag any delete of a key rather than just a value
+
+5. **Common.ps1 compliance**
+   - All writes must use `Set-RegistryValue`, not raw `New-Item`/`Set-ItemProperty`
+   - All deletes must use `Remove-RegistryValue`
+
+Output: table of key | operation | verdict (OK / WARNING / ERROR) | reason.

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -1,0 +1,22 @@
+---
+description: Generate a conventional commit message from staged changes
+agent: code
+---
+
+Generate a conventional commit message for the staged diff below.
+
+Staged diff:
+```diff
+!`git diff --staged 2>/dev/null | head -200`
+```
+
+Rules for this repository:
+- Format: `<type>: <subject>` (subject ≤72 chars, imperative mood)
+- Valid types: `feat` · `fix` · `docs` · `refactor` · `style` · `chore`
+- Body is optional; use it only when "why" isn't obvious from the subject
+- Do NOT include a body that just restates what the diff shows
+- PowerShell script additions: `feat: Add <script-name>.ps1 for <purpose>`
+- Registry tweak changes: `feat:` if new, `fix:` if correcting a value
+- Doc-only changes: `docs: Update AGENTS.md ...` or `docs: Update README.md ...`
+
+Output: the exact commit message string, nothing else. No quotes, no markdown fences.

--- a/.opencode/commands/lint.md
+++ b/.opencode/commands/lint.md
@@ -1,0 +1,22 @@
+---
+description: Run PSScriptAnalyzer on all PowerShell scripts and report violations
+agent: code
+---
+
+Run PSScriptAnalyzer across the repository. The CI enforces these same rules on every push.
+
+Target: `$ARGUMENTS` (default: all `.ps1` and `.psm1` files under `Scripts/`)
+
+Steps:
+1. Identify all PowerShell files in scope: `!`find Scripts/ -name "*.ps1" -o -name "*.psm1" | head -50``
+2. For each file, report any PSScriptAnalyzer violations. Focus on:
+   - `PSAvoidGlobalAliases` — banned by CI
+   - `PSAvoidUsingConvertToSecureStringWithPlainText` — banned by CI
+   - `PSAvoidUsingInvokeExpression` — security rule, also banned
+   - `PSUseDeclaredVarsMoreThanAssignments` — common dead-code
+   - OTBS brace style violations
+   - 2-space indent violations
+3. For each violation list: file, line, rule name, and a concrete fix.
+4. Do NOT auto-fix; present fixes for user review.
+
+Reference: `.github/workflows/powershell.yml` uses `microsoft/psscriptanalyzer-action` with `recurse: true`.

--- a/.opencode/commands/new-script.md
+++ b/.opencode/commands/new-script.md
@@ -1,0 +1,28 @@
+---
+description: Scaffold a new PowerShell script in Scripts/ following the standard pattern
+agent: code
+subtask: true
+---
+
+Create a new PowerShell script at `Scripts/$1.ps1` for the following purpose: $ARGUMENTS
+
+Requirements:
+1. File name: `$1.ps1` (lowercase-with-dashes, no spaces)
+2. Encoding: UTF-8 with BOM, CRLF line endings
+3. Mandatory header:
+   ```powershell
+   #Requires -RunAsAdministrator
+   . "$PSScriptRoot\Common.ps1"
+   ```
+4. Call `Request-AdminElevation` and `Initialize-ConsoleUI -Title "$1 (Administrator)"` at top-level
+5. Implement domain functions with comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`)
+6. Wire up the interactive menu loop using `Show-Menu` + `Get-MenuChoice` from Common.ps1
+7. Use `Set-RegistryValue`/`Remove-RegistryValue` for any registry operations — never raw `Set-ItemProperty`
+8. Set `Set-StrictMode -Version Latest` and `$ErrorActionPreference = "Stop"` inside each function
+9. Include a "Restore defaults" menu option for any registry or system changes
+10. No hardcoded paths — use `$PSScriptRoot` and `$HOME`
+
+After scaffolding, output:
+- The file contents
+- The git command to stage it: `git add Scripts/$1.ps1`
+- The suggested commit message following repo conventions

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,0 +1,48 @@
+---
+description: Diff-aware code review focused on PowerShell style, security, and Common.ps1 usage
+agent: code
+---
+
+Review the staged/unstaged changes for correctness, style compliance, and security.
+
+Changed files:
+```
+!`git diff HEAD --name-only 2>/dev/null | head -30`
+```
+
+Full diff:
+```diff
+!`git diff HEAD 2>/dev/null | head -300`
+```
+
+Review checklist — flag any violation:
+
+**Style (enforced by .editorconfig + PSScriptAnalyzer CI)**
+- [ ] OTBS braces: opening `{` on same line, never on new line
+- [ ] 2-space indent — no tabs anywhere in `.ps1`/`.psm1`
+- [ ] Spaces around operators (`=`, `+`, `-eq`, `|`)
+- [ ] Max line length 120 chars for PowerShell files
+- [ ] File named `lowercase-with-dashes.ps1`
+
+**Architecture**
+- [ ] New scripts are in `Scripts/`, not project root
+- [ ] Configs go in `user/.dotfiles/config/`, not `.config/` (deprecated)
+- [ ] No hardcoded paths — uses `$PSScriptRoot` or `$HOME`
+- [ ] Logic repeated ≥2 times is extracted to `Common.ps1`, not duplicated
+
+**Common.ps1 usage**
+- [ ] Script imports `. "$PSScriptRoot\Common.ps1"` before using shared functions
+- [ ] Uses `Set-RegistryValue`/`Remove-RegistryValue` — not direct `Set-ItemProperty`
+- [ ] Uses `Get-FileFromWeb` — not raw `Invoke-WebRequest` inline
+- [ ] Uses `Clear-DirectorySafe` for directory clearing (robocopy-backed)
+
+**Security**
+- [ ] No `Invoke-Expression` with variable input
+- [ ] No `$ErrorActionPreference = "SilentlyContinue"` at global scope
+- [ ] No hardcoded credentials, tokens, or personal paths
+- [ ] No `.gitconfig.local`, `.ssh/` (except `config`), or `local.ps1` staged
+
+**Comment-based help**
+- [ ] Every new public function has `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`
+
+Summarize: pass / fail per category. List each violation with file:line and suggested fix.

--- a/.opencode/skills/powershell-windows/SKILL.md
+++ b/.opencode/skills/powershell-windows/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: powershell-windows
+description: PowerShell scripting conventions for this Windows dotfiles repo — OTBS style, Common.ps1 usage, admin elevation, error handling, and comment-based help patterns used in Scripts/*.ps1
+---
+
+# PowerShell Windows Scripting
+
+## Mandatory header for every script in Scripts/
+
+```powershell
+#Requires -RunAsAdministrator
+. "$PSScriptRoot\Common.ps1"
+```
+
+## Top-level execution block
+
+```powershell
+Request-AdminElevation
+Initialize-ConsoleUI -Title "Script Name (Administrator)"
+```
+
+## Function structure
+
+```powershell
+<#
+.SYNOPSIS
+    One-line description.
+.DESCRIPTION
+    Extended description.
+.PARAMETER Name
+    What this parameter controls.
+.EXAMPLE
+    Enable-Feature -Name "value"
+#>
+function Enable-Feature {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Name
+  )
+
+  Set-StrictMode -Version Latest
+  $ErrorActionPreference = "Stop"
+
+  # implementation
+}
+```
+
+## Style rules (enforced by PSScriptAnalyzer CI)
+
+- OTBS: `{` on same line, never on a new line
+- 2-space indent — no tabs
+- Spaces around operators: `$x = $a + $b`, `$list | Where-Object { $_ -eq $x }`
+- Max 120 chars per line
+- File names: `lowercase-with-dashes.ps1`
+
+## Common.ps1 API — use these, do not re-implement
+
+| Task | Function |
+|------|----------|
+| Admin check | `Request-AdminElevation` |
+| Console setup | `Initialize-ConsoleUI -Title "..."` |
+| Show menu | `Show-Menu -Title "..." -Options @(...)` |
+| Get choice | `Get-MenuChoice -Min 1 -Max N` |
+| Write registry | `Set-RegistryValue -Path -Name -Type -Data` |
+| Delete registry value | `Remove-RegistryValue -Path -Name` |
+| NVIDIA GPU paths | `Get-NvidiaGpuRegistryPaths` |
+| Download file | `Get-FileFromWeb -URL -File` |
+| Clear directory | `Clear-DirectorySafe -Path` |
+| Parse Steam VDF | `ConvertFrom-VDF -Content` |
+| Serialize Steam VDF | `ConvertTo-VDF -Data` |
+
+## Interactive menu loop pattern
+
+```powershell
+while ($true) {
+  Show-Menu -Title "Feature Menu" -Options @("Enable", "Disable", "Status", "Exit")
+  $choice = Get-MenuChoice -Min 1 -Max 4
+
+  switch ($choice) {
+    1 { Enable-Feature }
+    2 { Disable-Feature }
+    3 { Show-Status }
+    4 { exit }
+  }
+
+  Read-Host "`nPress Enter to continue"
+}
+```
+
+## Banned patterns
+
+- `Invoke-Expression` with variable input → injection risk
+- `$ErrorActionPreference = "SilentlyContinue"` at global scope → silently hides failures
+- Hardcoded paths like `C:\Users\username\` → use `$HOME` or `$PSScriptRoot`
+- Raw `Set-ItemProperty` for registry → use `Set-RegistryValue` from Common.ps1
+- Duplicating logic that's already in Common.ps1

--- a/.opencode/skills/registry-tweaks/SKILL.md
+++ b/.opencode/skills/registry-tweaks/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: registry-tweaks
+description: Windows registry modification patterns for this repo — correct use of Common.ps1 Set-RegistryValue/Remove-RegistryValue, HKLM vs HKCU selection, REG_DWORD/REG_SZ/REG_BINARY types, and reversibility requirements
+---
+
+# Registry Tweaks
+
+## Correct write pattern
+
+```powershell
+# Always via Common.ps1 — never raw Set-ItemProperty
+Set-RegistryValue -Path "HKLM\SOFTWARE\Policies\Microsoft\Windows\..." `
+                  -Name "FeatureName" `
+                  -Type "REG_DWORD" `
+                  -Data "1"
+```
+
+## Correct delete pattern
+
+```powershell
+Remove-RegistryValue -Path "HKLM\SOFTWARE\..." -Name "FeatureName"
+```
+
+## HKLM vs HKCU
+
+| Use `HKLM` | Use `HKCU` |
+|---|---|
+| System-wide settings (all users) | Per-user settings |
+| GPU/display driver tweaks | User-specific shell/UI prefs |
+| Network stack settings | Profile/appearance settings |
+
+`HKLM` requires admin (`#Requires -RunAsAdministrator`). `HKCU` does not, but scripts still request elevation for consistency.
+
+## Value types
+
+| Type | Use case | Valid data |
+|---|---|---|
+| `REG_DWORD` | Flags, integers | 0–0xFFFFFFFF decimal or `"0x..."` hex |
+| `REG_SZ` | Plain strings | Any string (no `%VAR%` expansion) |
+| `REG_EXPAND_SZ` | Paths with env vars | Strings containing `%WINDIR%` etc. |
+| `REG_BINARY` | Raw byte data | Hex string pairs e.g. `"00,01,02"` |
+
+## Reversibility rule
+
+Every script that writes registry values MUST:
+1. Document the original/default value in a comment
+2. Offer a "Restore defaults" menu option that calls `Set-RegistryValue` with the original value
+3. Never delete a key (only values) unless absolutely required
+
+## NVIDIA GPU paths helper
+
+```powershell
+$gpuPaths = Get-NvidiaGpuRegistryPaths
+foreach ($path in $gpuPaths) {
+  Set-RegistryValue -Path $path -Name "..." -Type "REG_DWORD" -Data "1"
+}
+```
+
+## High-risk paths — always comment with justification
+
+- `HKLM\SYSTEM\CurrentControlSet\Services\*` — driver/service config, reboot required, can brick system
+- `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\*` — OS identity/boot config
+- `HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\*` — GPU driver config
+
+## .reg file format
+
+Files in `Scripts/reg/` follow standard `.reg` format. Always include a restore/undo `.reg` alongside any change `.reg`.

--- a/.opencode/skills/yadm-dotfiles/SKILL.md
+++ b/.opencode/skills/yadm-dotfiles/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: yadm-dotfiles
+description: yadm dotfile management workflow for this repo — tracking files under $HOME, bootstrap process, config file locations, and the distinction between yadm (dotfiles) and git (this Scripts repo)
+---
+
+# yadm Dotfiles Workflow
+
+## What yadm is
+
+yadm is a git wrapper that treats `$HOME` as the working tree. It tracks dotfiles (PowerShell profile, terminal config, etc.) without symlinks.
+
+## Key distinction
+
+| yadm | git |
+|---|---|
+| Manages dotfiles at `$HOME` | Manages this Scripts/config repo at `~/Win` |
+| `yadm add ~/.config/...` | `git add Scripts/new-script.ps1` |
+| `yadm push` to sync dotfiles | `git push` for this repo |
+
+## Dotfile locations
+
+All active configs live in `user/.dotfiles/config/` — NOT `.config/` (deprecated):
+
+| Config | Path |
+|---|---|
+| PowerShell profile | `user/.dotfiles/config/powershell/profile.ps1` |
+| Machine-local overrides | `user/.dotfiles/config/powershell/local.ps1` (gitignored) |
+| Windows Terminal | `user/.dotfiles/config/windows-terminal/settings.json` |
+| Game configs | `user/.dotfiles/config/games/<game>/` |
+| BleachBit cleaners | `user/.dotfiles/config/bleachbit/cleaners/` |
+
+## Bootstrap (new machine)
+
+```powershell
+winget install yadm
+yadm clone https://github.com/Ven0m0/Win.git
+pwsh $HOME\.yadm\bootstrap
+```
+
+Bootstrap sets up: PowerShell profile symlinks, Windows Terminal config, git defaults, dev tools via winget, Scripts dir added to PATH.
+
+## Common yadm commands
+
+```powershell
+yadm status           # what's changed in tracked dotfiles
+yadm diff             # see changes
+yadm add <file>       # track a new dotfile
+yadm commit -m "..."
+yadm push             # sync to remote
+yadm ls-files         # list all tracked dotfiles
+```
+
+## Never track
+
+- `user/.dotfiles/config/powershell/local.ps1` — machine-specific, gitignored
+- `.gitconfig` / `.gitconfig.local` — contain personal email
+- `.ssh/` directory (`.ssh/config` is OK)
+- Any `.env` file or token file


### PR DESCRIPTION
## Summary
This PR establishes comprehensive documentation and AI-assistant tooling for the Windows dotfiles repository. It adds Kilo Code skill guides covering PowerShell scripting conventions, registry modifications, and yadm dotfile management, along with architecture and security rules. It also introduces opencode command templates for code review, linting, and script scaffolding, plus a `.kilocodeignore` file to protect sensitive paths from AI tool access.

## Key Changes

**Skill Guides (`.kilocode/skills/` and `.opencode/skills/`)**
- `powershell-windows/SKILL.md` — PowerShell scripting conventions (OTBS style, Common.ps1 usage, admin elevation, error handling, comment-based help)
- `registry-tweaks/SKILL.md` — Registry modification patterns (Set-RegistryValue/Remove-RegistryValue usage, HKLM vs HKCU, value types, reversibility requirements)
- `yadm-dotfiles/SKILL.md` — yadm dotfile management workflow (distinction from git, config file locations, bootstrap process)

**Architecture & Code Style Rules (`.kilocode/rules/`)**
- `architecture.md` — Module boundaries, file organization, script structure requirements, deprecated paths
- `code-style.md` — PowerShell formatting (OTBS, 2-space indent, 120-char line limit), file naming conventions, comment-based help requirements
- `security.md` — Credential protection, injection prevention, script safety requirements, registry safety, hardcoded path bans
- `testing.md` — PSScriptAnalyzer as primary quality gate, manual testing protocol, CI gates, test coverage expectations

**Opencode Commands (`.opencode/commands/`)**
- `review.md` — Diff-aware code review checklist for style, architecture, Common.ps1 usage, and security
- `lint.md` — PSScriptAnalyzer runner with focus on CI-enforced rules
- `new-script.md` — Scaffold template for new PowerShell scripts following standard patterns
- `commit.md` — Conventional commit message generator
- `analyze-registry.md` — Audit registry operations for correctness and reversibility

**Access Control**
- `.kilocodeignore` — Protects secrets (.gitconfig, .ssh, tokens, env files), build artifacts, cache dirs, and CI reports from AI tool access
- `.ignore` — ripgrep ignore file for opencode tools (currently empty, extensible for future CI artifacts)

## Implementation Details

- All skill guides and rules are duplicated in both `.kilocode/` and `.opencode/` directories to support both Kilo Code and opencode AI assistants
- `.kilocodeignore` uses gitignore-style patterns with `!` un-ignore support; blocks `execute_command` against sensitive paths to prevent shell injection attacks
- Command templates use `!` backtick syntax for dynamic content (git diff, file discovery) and `$ARGUMENTS`/`$1` for parameterization
- Documentation emphasizes Common.ps1 as the single shared library, OTBS brace style, and reversibility for all system modifications

https://claude.ai/code/session_019MEhrEbK1pnda8B2cD7Wwf