### PR TITLE
🧹 Remove unused Set-NetOffloadGlobalSetting line

### DIFF
--- a/Scripts/Network-Tweaker.ps1
+++ b/Scripts/Network-Tweaker.ps1
@@ -2340,7 +2340,6 @@ function applyglobal {
     else
     {
         Write-Host "Applying NetworkDirect to"$cb_osntd.text -ForegroundColor Green
-        #Set-NetOffloadGlobalSetting -NetworkDirect $cb_osntd.text
         Apply_NetworkDirect
         $cb_osntd.text = (Get-NetOffloadGlobalSetting | Select-Object -expand NetworkDirect)
     }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,11 @@
+🎯 **What:** Removed commented-out dead code `#Set-NetOffloadGlobalSetting -NetworkDirect $cb_osntd.text` from `Scripts/Network-Tweaker.ps1`.
+
+💡 **Why:** This code was likely replaced by `Apply_NetworkDirect` on the next line. Removing this unused, commented-out line reduces confusion for future maintainers and improves overall code readability and maintainability.
+
+✅ **Verification:**
+- Due to the testing environment lacking `pwsh`, tests were not run directly via CI/CLI, but a manual visual inspection was done.
+- The Python-based line removal specifically targeted exactly the line in question without altering whitespace context.
+- BOM and CRLF line endings were preserved.
+- The change removes exclusively commented out code so there is strictly zero impact on the application's runtime behavior.
+
+✨ **Result:** A cleaner and more readable script section without obsolete dead code.


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code `#Set-NetOffloadGlobalSetting -NetworkDirect $cb_osntd.text` from `Scripts/Network-Tweaker.ps1`.

💡 **Why:** This code was likely replaced by `Apply_NetworkDirect` on the next line. Removing this unused, commented-out line reduces confusion for future maintainers and improves overall code readability and maintainability.

✅ **Verification:** 
- Due to the testing environment lacking `pwsh`, tests were not run directly via CI/CLI, but a manual visual inspection was done.
- The Python-based line removal specifically targeted exactly the line in question without altering whitespace context.
- BOM and CRLF line endings were preserved.
- The change removes exclusively commented out code so there is strictly zero impact on the application's runtime behavior.

✨ **Result:** A cleaner and more readable script section without obsolete dead code.

---
*PR created automatically by Jules for task [15419527506040193915](https://jules.google.com/task/15419527506040193915) started by @Ven0m0*