### PR TITLE
⚡ Optimize VDF parsing and array concatenation in shader-cache.ps1

### DIFF
--- a/Scripts/shader-cache.ps1
+++ b/Scripts/shader-cache.ps1
@@ -24,13 +24,15 @@ $apps = @(
 #--- Find per-app install locations (using Common.ps1 VDF parser)
 $vdf=(Get-Content "$STEAM\steamapps\libraryfolders.vdf" -Force -ErrorAction SilentlyContinue)
 if (!$vdf) { $vdf = @('"libraryfolders"','{','}') }
-$roots = @()
-foreach ($nr in (ConvertFrom-VDF -Content $vdf).Item(0).Keys) {
-  $entry = (ConvertFrom-VDF -Content $vdf).Item(0)[$nr]
+$vdfParsed = (ConvertFrom-VDF -Content $vdf).Item(0)
+$rootsList = [System.Collections.Generic.List[string]]::new()
+foreach ($nr in $vdfParsed.Keys) {
+  $entry = $vdfParsed[$nr]
   if ($entry -and $entry["path"]) {
-    $roots += $entry["path"].Trim('"')
+    $rootsList.Add($entry["path"].Trim('"'))
   }
 }
+$roots = $rootsList.ToArray()
 foreach ($app in $apps) {
   foreach ($root in $roots) {
     $i = "$root\steamapps\common\$($app.installdir)"


### PR DESCRIPTION
💡 **What:** Optimized the VDF parsing loop in `Scripts/shader-cache.ps1` by caching the result of `ConvertFrom-VDF` outside the loop and replacing the inefficient `$roots +=` array concatenation with a `[System.Collections.Generic.List[string]]`, which is finally converted back to an array to maintain backwards compatibility.

🎯 **Why:** The original code had two major performance issues:
1. It invoked the `ConvertFrom-VDF` function repeatedly inside the loop for every single key in the `.Keys` collection, resulting in O(N^2) overhead for parsing the VDF content.
2. It used the `$roots +=` anti-pattern. This recreates the entire array in memory upon each append, causing a progressive performance downgrade as the array grows.

📊 **Measured Improvement:**
Since `powershell` is not available in the development environment to execute runtime benchmarks, I performed static analysis to verify the performance gain.
- **Baseline:** VDF parser invoked `N+1` times where N is the number of keys. Array memory dynamically reallocated `M` times where M is the number of valid paths.
- **Improved:** VDF parser invoked exactly **1** time. Array memory pre-allocated via `List[string]` scaling linearly in O(1) per insertion without full reallocation.

*Note: Automated testing was skipped as `pwsh`/`powershell` is not available in the current environment.*

---
*PR created automatically by Jules for task [13726053362074619225](https://jules.google.com/task/13726053362074619225) started by @Ven0m0*