### PR TITLE
🧹 remove unused function Remove-InstalledApp

### DIFF
--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -127,12 +127,6 @@ function Install-CustomPackage {
   }
 }
 
-function Remove-InstalledApp {
-  param([Parameter(Mandatory)][string]$Package)
-  Write-Verbose "Uninstalling: $Package"
-  Run-Elevated -FilePath "PowerShell" -ArgumentList "Get-AppxPackage","-AllUsers","-Name","'$Package'" -Hidden
-}
-
 function Enable-Bucket {
   param([Parameter(Mandatory)][string]$Bucket)
   if (-not ((scoop bucket list).Name -eq "$Bucket")) {


### PR DESCRIPTION
🎯 **What:** Removed the unused `Remove-InstalledApp` function from `Scripts/shell-setup.ps1`.
💡 **Why:** This improves maintainability and readability by eliminating dead code. The functionality is superseded by the `Remove-AppxPackageSafe` helper in `Scripts/Common.ps1`.
✅ **Verification:** Performed a global search for usages of `Remove-InstalledApp` and found none. Manually inspected the script to ensure structural integrity and verified the removal with `read_file`.
✨ **Result:** A cleaner, more maintainable `shell-setup.ps1` script with reduced overhead.

---
*PR created automatically by Jules for task [12274461333385960233](https://jules.google.com/task/12274461333385960233) started by @Ven0m0*