### PR TITLE
🔒 fix: secure remote script execution by removing iex

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Maintainability](https://qlty.sh/gh/Ven0m0/projects/.github/maintainability.svg)](https://qlty.sh/gh/Ven0m0/projects/.github)
 
 - [Winget](https://winstall.app)
-- [Scoop](https://scoop.sh) `iex "& {$(irm get.scoop.sh)} -RunAsAdmin"`
+- [Scoop](https://scoop.sh) (Install via official site or use the secure pattern in `Scripts/shell-setup.ps1`)
 - [Chocolatey](https://chocolatey.org)
-- CCT: `iwr -useb https://christitus.com/win | iex`
+- CCT (Chris Titus Tech): Use the `winutil` function defined in the PowerShell profile
 
 My Windows configuration files and scripts, managed with [yadm](https://yadm.io/).
 

--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -155,21 +155,32 @@ if ((Get-ExecutionPolicy -Scope CurrentUser) -notcontains "Unrestricted") {
 # Scoop
 if (-not (Get-Command -Name "scoop" -CommandType Application -ErrorAction SilentlyContinue)) {
   Write-Verbose "Installing Scoop..."
-  $scoopInstaller = Join-Path $Env:Temp "install-scoop.ps1"
-  Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
-  & $scoopInstaller
-  Remove-Item -LiteralPath $scoopInstaller -Force
+  $scoopInstaller = Join-Path $Env:Temp ("install-scoop-{0}.ps1" -f [System.Guid]::NewGuid().ToString('N'))
+  try {
+    Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
+    & $scoopInstaller
+  } finally {
+    if (Test-Path -LiteralPath $scoopInstaller) {
+      Remove-Item -LiteralPath $scoopInstaller -Force
+    }
+  }
 }
 
 # Chocolatey
 if (-not (Get-Command -Name "choco" -CommandType Application -ErrorAction SilentlyContinue)) {
-  Write-Verbose "Installing Chocolatey..."
-  @'
+Write-Verbose "Installing Chocolatey..."
+@'
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-$chocoInstaller = Join-Path $Env:Temp "install-choco.ps1"
-Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile $chocoInstaller
-& $chocoInstaller
-Remove-Item -LiteralPath $chocoInstaller -Force
+$chocoInstaller = Join-Path $Env:Temp ("install-choco-{0}.ps1" -f [System.Guid]::NewGuid().ToString())
+try {
+  Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile $chocoInstaller
+  & $chocoInstaller
+}
+finally {
+  if (Test-Path -LiteralPath $chocoInstaller) {
+    Remove-Item -LiteralPath $chocoInstaller -Force
+  }
+}
 '@ > $Env:Temp\choco.ps1
   Run-Elevated -FilePath "PowerShell" -ArgumentList "$Env:Temp\choco.ps1"
   Remove-Item -LiteralPath $Env:Temp\choco.ps1 -Force
@@ -406,10 +417,16 @@ $PS7 = winget list --exact -q Microsoft.PowerShell
 if (-not $PS7) {
   Write-Verbose "Installing PowerShell 7..."
 @'
-$ps7Installer = Join-Path $Env:Temp "install-powershell.ps1"
-Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1' -OutFile $ps7Installer
-& $ps7Installer -UseMSI -Quiet
-Remove-Item -LiteralPath $ps7Installer -Force
+$ps7Installer = Join-Path $Env:Temp ("install-powershell-{0}.ps1" -f [System.Guid]::NewGuid().ToString())
+try {
+  Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1' -OutFile $ps7Installer
+  & $ps7Installer -UseMSI -Quiet
+}
+finally {
+  if (Test-Path -LiteralPath $ps7Installer) {
+    Remove-Item -LiteralPath $ps7Installer -Force
+  }
+}
 '@ > $Env:Temp\ps7.ps1
   Run-Elevated -FilePath "PowerShell" -ArgumentList "$Env:Temp\ps7.ps1" -Hidden
   Remove-Item -LiteralPath $Env:Temp\ps7.ps1 -Force

--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -155,7 +155,10 @@ if ((Get-ExecutionPolicy -Scope CurrentUser) -notcontains "Unrestricted") {
 # Scoop
 if (-not (Get-Command -Name "scoop" -CommandType Application -ErrorAction SilentlyContinue)) {
   Write-Verbose "Installing Scoop..."
-  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh'))
+  $scoopInstaller = Join-Path $Env:Temp "install-scoop.ps1"
+  Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
+  & $scoopInstaller
+  Remove-Item -LiteralPath $scoopInstaller -Force
 }
 
 # Chocolatey
@@ -163,7 +166,10 @@ if (-not (Get-Command -Name "choco" -CommandType Application -ErrorAction Silent
   Write-Verbose "Installing Chocolatey..."
   @'
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+$chocoInstaller = Join-Path $Env:Temp "install-choco.ps1"
+Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile $chocoInstaller
+& $chocoInstaller
+Remove-Item -LiteralPath $chocoInstaller -Force
 '@ > $Env:Temp\choco.ps1
   Run-Elevated -FilePath "PowerShell" -ArgumentList "$Env:Temp\choco.ps1"
   Remove-Item -LiteralPath $Env:Temp\choco.ps1 -Force
@@ -400,7 +406,10 @@ $PS7 = winget list --exact -q Microsoft.PowerShell
 if (-not $PS7) {
   Write-Verbose "Installing PowerShell 7..."
 @'
-iex "& { $(irm https://aka.ms/install-powershell.ps1) } -UseMSI -Quiet"
+$ps7Installer = Join-Path $Env:Temp "install-powershell.ps1"
+Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1' -OutFile $ps7Installer
+& $ps7Installer -UseMSI -Quiet
+Remove-Item -LiteralPath $ps7Installer -Force
 '@ > $Env:Temp\ps7.ps1
   Run-Elevated -FilePath "PowerShell" -ArgumentList "$Env:Temp\ps7.ps1" -Hidden
   Remove-Item -LiteralPath $Env:Temp\ps7.ps1 -Force

--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -244,10 +244,18 @@ function Get-PubIP { (Invoke-WebRequest https://ifconfig.me/ip).Content }
 
 # Open WinUtil full-release
 function winutil {
-  $winutilInstaller = Join-Path $Env:Temp "winutil.ps1"
-  Invoke-RestMethod -Uri 'https://christitus.com/win' -OutFile $winutilInstaller
-  & $winutilInstaller
-  Remove-Item -LiteralPath $winutilInstaller -Force
+  $temporaryFile = New-TemporaryFile
+  $winutilInstaller = [System.IO.Path]::ChangeExtension($temporaryFile.FullName, '.ps1')
+  Move-Item -LiteralPath $temporaryFile.FullName -Destination $winutilInstaller -Force
+
+  try {
+    Invoke-RestMethod -Uri 'https://christitus.com/win' -OutFile $winutilInstaller
+    & $winutilInstaller
+  } finally {
+    if (Test-Path -LiteralPath $winutilInstaller) {
+      Remove-Item -LiteralPath $winutilInstaller -Force
+    }
+  }
 }
 
 # System Utilities

--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -243,7 +243,12 @@ function mkcd {
 function Get-PubIP { (Invoke-WebRequest https://ifconfig.me/ip).Content }
 
 # Open WinUtil full-release
-function winutil { irm https://christitus.com/win | iex }
+function winutil {
+  $winutilInstaller = Join-Path $Env:Temp "winutil.ps1"
+  Invoke-RestMethod -Uri 'https://christitus.com/win' -OutFile $winutilInstaller
+  & $winutilInstaller
+  Remove-Item -LiteralPath $winutilInstaller -Force
+}
 
 # System Utilities
 function admin {


### PR DESCRIPTION
This PR addresses a security vulnerability where remote scripts were executed directly in memory using `Invoke-Expression`. I have refactored the installation logic for Scoop, Chocolatey, PowerShell 7, and the `winutil` function to download scripts to a temporary file before execution. This approach ensures that the execution is visible to system security tools and adheres to PowerShell security best practices.

---
*PR created automatically by Jules for task [17185200147341302696](https://jules.google.com/task/17185200147341302696) started by @Ven0m0*