### PR TITLE
🧹 [code health] Remove unused Show-RegistryStatus function

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -331,59 +331,6 @@ function Show-NvidiaGpuSettings {
   }
 }
 
-function Show-RegistryStatus {
-    <#
-    .SYNOPSIS
-        Displays registry value status with color-coded output
-    .PARAMETER Path
-        Registry path (in PowerShell format like 'HKLM:\SOFTWARE\...')
-    .PARAMETER Name
-        Registry value name
-    .PARAMETER Label
-        Display label for the setting
-    .PARAMETER EnabledValue
-        Value that indicates "enabled" state
-    .PARAMETER EnabledText
-        Text to show when enabled (default: "Enabled")
-    .PARAMETER DisabledText
-        Text to show when disabled (default: "Disabled")
-    .PARAMETER NotFoundText
-        Text to show when not found (default: "Not configured")
-    #>
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path,
-
-        [Parameter(Mandatory)]
-        [string]$Name,
-
-        [string]$Label,
-        [object]$EnabledValue = 1,
-        [string]$EnabledText = "Enabled",
-        [string]$DisabledText = "Disabled",
-        [string]$NotFoundText = "Not configured"
-    )
-
-    if (!$Label) {
-        $Label = $Name
-    }
-
-    try {
-        $value = (Get-ItemProperty -Path $Path -Name $Name -ErrorAction Stop).$Name
-
-        if ($value -eq $EnabledValue) {
-            Write-Host "${Label}: " -NoNewline
-            Write-Host $EnabledText -ForegroundColor Green
-        } else {
-            Write-Host "${Label}: " -NoNewline
-            Write-Host $DisabledText -ForegroundColor Yellow
-        }
-    } catch {
-        Write-Host "${Label}: " -NoNewline
-        Write-Host $NotFoundText -ForegroundColor Gray
-    }
-}
-
 function Get-RegistryValueSafe {
     <#
     .SYNOPSIS

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,7 @@
+🎯 **What:** Removed the `Show-RegistryStatus` function from `Scripts/Common.ps1`.
+
+💡 **Why:** A codebase search (`grep`) revealed that `Show-RegistryStatus` is an unused function (dead code). Removing it reduces file size, decreases clutter in the shared utility script, and improves overall codebase maintainability without affecting any running scripts.
+
+✅ **Verification:** Verified the removal of lines 334 to 385 containing the function declaration and body manually using a Python script reading the file in binary mode to ensure CRLF was preserved. Confirmed using `git diff` that no other parts of `Scripts/Common.ps1` were inadvertently altered. Testing with `pwsh` was omitted because `pwsh` is unavailable in the current development environment.
+
+✨ **Result:** A cleaner `Scripts/Common.ps1` without unused logic, leading to improved code readability.


### PR DESCRIPTION
🎯 **What:** Removed the `Show-RegistryStatus` function from `Scripts/Common.ps1`.

💡 **Why:** A codebase search (`grep`) revealed that `Show-RegistryStatus` is an unused function (dead code). Removing it reduces file size, decreases clutter in the shared utility script, and improves overall codebase maintainability without affecting any running scripts.

✅ **Verification:** Verified the removal of lines 334 to 385 containing the function declaration and body manually using a Python script reading the file in binary mode to ensure CRLF was preserved. Confirmed using `git diff` that no other parts of `Scripts/Common.ps1` were inadvertently altered. Testing with `pwsh` was omitted because `pwsh` is unavailable in the current development environment.

✨ **Result:** A cleaner `Scripts/Common.ps1` without unused logic, leading to improved code readability.

---
*PR created automatically by Jules for task [15563207480198465545](https://jules.google.com/task/15563207480198465545) started by @Ven0m0*