### PR TITLE
🧹 Remove unused function Get-WingetUpgradeablePackageIds

### DIFF
--- a/Scripts/system-update.ps1
+++ b/Scripts/system-update.ps1
@@ -468,18 +468,6 @@ function Get-WingetPinnedPackageIds {
     return @($pkgIds)
 }
 
-function Get-WingetUpgradeablePackageIds {
-    param([string]$WingetOutput)
-
-    $pkgIds = [System.Collections.Generic.List[string]]::new()
-    foreach ($entry in (Get-WingetUpgradeEntries -WingetOutput $WingetOutput)) {
-        if (-not $pkgIds.Contains($entry.Id)) {
-            $pkgIds.Add($entry.Id)
-        }
-    }
-    return @($pkgIds)
-}
-
 function Get-VSCodeCliPath {
     $candidates = @(
         (Join-Path $env:LOCALAPPDATA 'Programs\Microsoft VS Code\bin\code.cmd'),


### PR DESCRIPTION
🎯 **What:** Removed unused function `Get-WingetUpgradeablePackageIds` from `Scripts/system-update.ps1`.
💡 **Why:** The function was unused dead code. Removing it improves codebase maintainability.
✅ **Verification:** Verified function uses using grep, confirmed removal leaves script in a valid state.
✨ **Result:** A cleaner script file without unnecessary code.

---
*PR created automatically by Jules for task [15358386576677919694](https://jules.google.com/task/15358386576677919694) started by @Ven0m0*