### PR TITLE
🧹 Remove unused Reset-StepState function

### DIFF
--- a/Scripts/system-update.ps1
+++ b/Scripts/system-update.ps1
@@ -689,7 +689,6 @@ function Invoke-Update {
 $script:stepChanged = $false
 $script:stepMessage = ""
 
-function Reset-StepState { $script:stepChanged = $false; $script:stepMessage = "" }
 
 function Complete-StepState {
     if ([string]::IsNullOrWhiteSpace($script:stepMessage)) {


### PR DESCRIPTION
🎯 **What:** Removed the `Reset-StepState` function from `Scripts/system-update.ps1`.
💡 **Why:** The function was unused dead code. Removing it improves codebase maintainability and reduces clutter.
✅ **Verification:** Verified via `git grep` that there are no remaining usages of `Reset-StepState` in the codebase. Testing via `pwsh` was not feasible in the current Linux environment, but the removal is safe as the function was isolated and unreferenced.
✨ **Result:** A cleaner `Scripts/system-update.ps1` script without dead code.

---
*PR created automatically by Jules for task [16537262051294817933](https://jules.google.com/task/16537262051294817933) started by @Ven0m0*