### PR TITLE
🧹 Remove unused Assert-Admin function

### DIFF
--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -12,13 +12,6 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $VerbosePreference = 'Continue'
 
-function Assert-Admin {
-  $p = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-  if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    throw "Administrator privileges required."
-  }
-}
-
 function Run-Elevated {
   param(
     [Parameter(Mandatory)] [string]$FilePath,


### PR DESCRIPTION
🎯 What: Removed the unused Assert-Admin function from Scripts/shell-setup.ps1.
💡 Why: The function is no longer referenced anywhere in the codebase. Removing dead code improves readability and maintainability.
✅ Verification: Grepped the codebase to confirm no usages exist. Ran PSScriptAnalyzer to ensure the script remains syntactically valid after removal.
✨ Result: Scripts/shell-setup.ps1 is cleaner and free of dead code.

---
*PR created automatically by Jules for task [16537262051294817732](https://jules.google.com/task/16537262051294817732) started by @Ven0m0*