### PR TITLE
🧹 Remove duplicate mkcd function definition

### DIFF
--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -307,8 +307,6 @@ function tail {
 # Quick File Creation
 function nf { param($name) New-Item -ItemType "file" -Path . -Name $name }
 
-# Directory Management
-function mkcd { param($dir) mkdir $dir -Force; Set-Location $dir }
 
 function trash($path) {
     $fullPath = (Resolve-Path -Path $path).Path


### PR DESCRIPTION
🎯 **What:** Removed duplicate one-line mkcd definition from profile.ps1.
💡 **Why:** Overwrites robust existing definition with basic, error-prone version.
✅ **Verification:** Verified with PSScriptAnalyzer.
✨ **Result:** Only the proper definition remains, avoiding overwrite and preventing loss of features in the original function.

---
*PR created automatically by Jules for task [5807903917378149280](https://jules.google.com/task/5807903917378149280) started by @Ven0m0*