### PR TITLE
🧹 Remove duplicate HistorySearchBackward binding

### DIFF
--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -478,7 +478,6 @@ if (Get-Module -ListAvailable -Name PSReadLine) {
 
     # History configuration
     Set-PSReadLineOption -HistorySearchCursorMovesToEnd
-    Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
     Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
 
     # Tab completion


### PR DESCRIPTION
🎯 **What:** Removed a duplicated `Set-PSReadLineKeyHandler` configuration for `HistorySearchBackward` on the `UpArrow` key in the PowerShell profile script.
💡 **Why:** To improve code health and maintainability by removing redundant code, ensuring key bindings are only defined once without inadvertently removing functional configuration for other keys.
✅ **Verification:** Verified with PSScriptAnalyzer that the changes do not introduce syntax errors or regressions, and visually confirmed only the single duplicate line was removed.
✨ **Result:** A cleaner, more maintainable PowerShell profile script with no changes to the user's expected behavior.

---
*PR created automatically by Jules for task [10686041552459718339](https://jules.google.com/task/10686041552459718339) started by @Ven0m0*