### PR TITLE
🧹 DRY up Git and Yadm alias configuration

### DIFF
--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -86,23 +86,18 @@ if (Get-Module -ListAvailable -Name PSColor) {
     }
 }
 
-# Git aliases (if git is installed)
-if (Get-Command git -ErrorAction SilentlyContinue) {
-    function gs { git status $args }
-    function ga { git add $args }
-    function gc { git commit $args }
-    function gp { git push $args }
-    function gl { git log --oneline --graph --decorate $args }
-    function gd { git diff $args }
-}
-
-# yadm aliases
-if (Get-Command yadm -ErrorAction SilentlyContinue) {
-    function ys { yadm status $args }
-    function ya { yadm add $args }
-    function yc { yadm commit $args }
-    function yp { yadm push $args }
-    function yl { yadm log --oneline --graph --decorate $args }
+# VCS aliases (git, yadm)
+$vcsTools = @('git', 'yadm')
+foreach ($cmd in $vcsTools) {
+    if (Get-Command $cmd -ErrorAction SilentlyContinue) {
+        $prefix = $cmd.Substring(0, 1)
+        Set-Item -Path "Function:${prefix}s" -Value ([scriptblock]::Create("$cmd status `$args"))
+        Set-Item -Path "Function:${prefix}a" -Value ([scriptblock]::Create("$cmd add `$args"))
+        Set-Item -Path "Function:${prefix}c" -Value ([scriptblock]::Create("$cmd commit `$args"))
+        Set-Item -Path "Function:${prefix}p" -Value ([scriptblock]::Create("$cmd push `$args"))
+        Set-Item -Path "Function:${prefix}l" -Value ([scriptblock]::Create("$cmd log --oneline --graph --decorate `$args"))
+        Set-Item -Path "Function:${prefix}d" -Value ([scriptblock]::Create("$cmd diff `$args"))
+    }
 }
 
 # Docker aliases (if docker is installed)


### PR DESCRIPTION
🎯 **What:** DRY'd up the duplicated logic between Git and Yadm aliases in the PowerShell profile (`user/.dotfiles/config/powershell/profile.ps1`).
💡 **Why:** To improve code maintainability, avoid repeating the exact same alias definitions (e.g., status, add, commit) for both Git and Yadm, and to implicitly add the missing `yd` (diff) alias to the yadm tool.
✅ **Verification:** Validated that the dynamic syntax using `Set-Item` and `[scriptblock]::Create` safely evaluates without errors in PowerShell 7, passing `Invoke-ScriptAnalyzer` with no new warnings. 
✨ **Result:** The repeated alias creation blocks are now combined into a single concise loop, resolving the duplication health issue.

---
*PR created automatically by Jules for task [10037381603076417128](https://jules.google.com/task/10037381603076417128) started by @Ven0m0*