### PR TITLE
🧹 Extract duplicate NvidiaProfileInspector installation logic

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+🎯 **What:** Extracted the duplicate installation logic for `NvidiaProfileInspector` inside the `nvidia-settings.ps1` script from the `1 {` and `2 {` switch cases, moving it before the switch statement inside the valid choice condition block.
+💡 **Why:** This refactoring reduces code duplication, improving maintainability. By executing the shared block once instead of maintaining it in two places, we prevent future bugs where updates to the installation step are only applied to one profile condition.
+✅ **Verification:** Verified the logic remains intact—the valid profile inputs (1 and 2) correctly execute the inspector installation block before branching into profile-specific configurations. Verified syntax using `PSScriptAnalyzer`.
+✨ **Result:** A cleaner and smaller `nvidia-settings.ps1` script with reduced duplication while preserving all behavior.

--- a/user/.dotfiles/config/nvidia-inspector/nvidia-settings.ps1
+++ b/user/.dotfiles/config/nvidia-inspector/nvidia-settings.ps1
@@ -46,16 +46,17 @@
     while ($true) {
     $choice = Read-Host " "
     if ($choice -match '^[1-2]$') {
+
+    Clear-Host
+    Write-Host "Installing: NvidiaProfileInspector . . ."
+    # unblock drs files
+    $path = "C:\ProgramData\NVIDIA Corporation\Drs"
+    Get-ChildItem -Path $path -Recurse | Unblock-File
+    # download inspector
+    Get-FileFromWeb -URL "https://github.com/FR33THYFR33THY/files/raw/main/Inspector.exe" -File "$env:TEMP\Inspector.exe"
+
     switch ($choice) {
     1 {
-
-Clear-Host
-Write-Host "Installing: NvidiaProfileInspector . . ."
-# unblock drs files
-$path = "C:\ProgramData\NVIDIA Corporation\Drs"
-Get-ChildItem -Path $path -Recurse | Unblock-File
-# download inspector
-Get-FileFromWeb -URL "https://github.com/FR33THYFR33THY/files/raw/main/Inspector.exe" -File "$env:TEMP\Inspector.exe"
 # create config for inspector
 $MultilineComment = @"
 <?xml version="1.0" encoding="utf-16"?>
@@ -267,14 +268,6 @@ exit
 
       }
     2 {
-
-Clear-Host
-Write-Host "Installing: NvidiaProfileInspector . . ."
-# unblock drs files
-$path = "C:\ProgramData\NVIDIA Corporation\Drs"
-Get-ChildItem -Path $path -Recurse | Unblock-File
-# download inspector
-Get-FileFromWeb -URL "https://github.com/FR33THYFR33THY/files/raw/main/Inspector.exe" -File "$env:TEMP\Inspector.exe"
 # create config for inspector
 $MultilineComment = @"
 <?xml version="1.0" encoding="utf-16"?>


### PR DESCRIPTION
🎯 **What:** Extracted the duplicate installation logic for `NvidiaProfileInspector` inside the `nvidia-settings.ps1` script from the `1 {` and `2 {` switch cases, moving it before the switch statement inside the valid choice condition block.
💡 **Why:** This refactoring reduces code duplication, improving maintainability. By executing the shared block once instead of maintaining it in two places, we prevent future bugs where updates to the installation step are only applied to one profile condition.
✅ **Verification:** Verified the logic remains intact—the valid profile inputs (1 and 2) correctly execute the inspector installation block before branching into profile-specific configurations. Verified syntax using `PSScriptAnalyzer`.
✨ **Result:** A cleaner and smaller `nvidia-settings.ps1` script with reduced duplication while preserving all behavior.

---
*PR created automatically by Jules for task [16590201036896110243](https://jules.google.com/task/16590201036896110243) started by @Ven0m0*