### PR TITLE
🧹 [code health] Use [void] instead of Out-Null in NvidiaAutoinstall.ps1

### DIFF
--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -63,23 +63,19 @@ function Edit-Nip {
     if ($settingNameInfo) {
         $newsettingNameInfo.InnerText = $settingNameInfo
     }
-    $newSetting.AppendChild($newsettingNameInfo) | Out-Null
-
+    [void]($newSetting.AppendChild($newsettingNameInfo))
     #create the new setting
     $newsettingID = $nipContent.CreateElement('SettingID')
     $newsettingID.InnerText = $settingId
-    $newSetting.AppendChild($newsettingID) | Out-Null
-
+    [void]($newSetting.AppendChild($newsettingID))
     $newsettingValue = $nipContent.CreateElement('SettingValue')
     $newsettingValue.InnerText = $settingValue
-    $newSetting.AppendChild($newsettingValue) | Out-Null
-
+    [void]($newSetting.AppendChild($newsettingValue))
     $newvalueType = $nipContent.CreateElement('ValueType')
     $newvalueType.InnerText = $valueType
-    $newSetting.AppendChild($newvalueType) | Out-Null
-
+    [void]($newSetting.AppendChild($newvalueType))
     #add new setting to nip
-    $settings.AppendChild($newSetting) | Out-Null
+    [void]($settings.AppendChild($newSetting))
     $nipContent.Save($nipPath)
 
 
@@ -97,11 +93,11 @@ function Run-Trusted([String]$command) {
     $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
     $base64Command = [Convert]::ToBase64String($bytes)
     #change bin to command
-    sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command" | Out-Null
+    [void](sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command")
     #run the command
-    sc.exe start TrustedInstaller | Out-Null
+    [void](sc.exe start TrustedInstaller)
     #set bin back to default
-    sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"" | Out-Null
+    [void](sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"")
     Stop-Service -Name TrustedInstaller -Force -ErrorAction SilentlyContinue
 
 }
@@ -190,7 +186,7 @@ if (!(Check-Internet)) {
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
     -Name 'Userinit' -Value `"$currentValue`"
                 "
-                New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force | Out-Null
+                [void](New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force)
                 #create winlogon key
                 $scriptRun = "powershell.exe -nop -ep bypass -f $env:TEMP\safemodescript.ps1"
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'


### PR DESCRIPTION
🎯 **What:** Replaced instances of `| Out-Null` with `[void](...)` throughout `user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1`.
💡 **Why:** Using `[void]` prefix is more performant than piping to `Out-Null` as it avoids the execution overhead of setting up and passing data through the PowerShell pipeline. This improves execution speed and code maintainability, adhering to preferred PowerShell performance guidelines.
✅ **Verification:** Verified that PSScriptAnalyzer detected no syntax errors or new severity warnings. Pester tests (`Common.Tests.ps1`) run but any failures are pre-existing and unrelated to this script. The structural change safely preserves the functionality and script logic using a Python script handling accurate search-and-replace, retaining both the CRLF formatting and BOM header.
✨ **Result:** Improved script execution efficiency and code standard compliance without altering behavior.

---
*PR created automatically by Jules for task [16658843044492300834](https://jules.google.com/task/16658843044492300834) started by @Ven0m0*