### PR TITLE
🧹 Replace `| Out-Null` with `[void](...)` in NvidiaAutoinstall.ps1

### DIFF
--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -63,23 +63,23 @@ function Edit-Nip {
     if ($settingNameInfo) {
         $newsettingNameInfo.InnerText = $settingNameInfo
     }
-    $newSetting.AppendChild($newsettingNameInfo) | Out-Null
+    [void]($newSetting.AppendChild($newsettingNameInfo))
 
     #create the new setting
     $newsettingID = $nipContent.CreateElement('SettingID')
     $newsettingID.InnerText = $settingId
-    $newSetting.AppendChild($newsettingID) | Out-Null
+    [void]($newSetting.AppendChild($newsettingID))
 
     $newsettingValue = $nipContent.CreateElement('SettingValue')
     $newsettingValue.InnerText = $settingValue
-    $newSetting.AppendChild($newsettingValue) | Out-Null
+    [void]($newSetting.AppendChild($newsettingValue))
 
     $newvalueType = $nipContent.CreateElement('ValueType')
     $newvalueType.InnerText = $valueType
-    $newSetting.AppendChild($newvalueType) | Out-Null
+    [void]($newSetting.AppendChild($newvalueType))
 
     #add new setting to nip
-    $settings.AppendChild($newSetting) | Out-Null
+    [void]($settings.AppendChild($newSetting))
     $nipContent.Save($nipPath)
 
 
@@ -97,11 +97,11 @@ function Run-Trusted([String]$command) {
     $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
     $base64Command = [Convert]::ToBase64String($bytes)
     #change bin to command
-    sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command" | Out-Null
+    [void](sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command")
     #run the command
-    sc.exe start TrustedInstaller | Out-Null
+    [void](sc.exe start TrustedInstaller)
     #set bin back to default
-    sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"" | Out-Null
+    [void](sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"")
     Stop-Service -Name TrustedInstaller -Force -ErrorAction SilentlyContinue
 
 }
@@ -190,7 +190,7 @@ if (!(Check-Internet)) {
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
     -Name 'Userinit' -Value `"$currentValue`"
                 "
-                New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force | Out-Null
+                [void](New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force)
                 #create winlogon key
                 $scriptRun = "powershell.exe -nop -ep bypass -f $env:TEMP\safemodescript.ps1"
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'


### PR DESCRIPTION
🎯 **What:** Replaced usages of `| Out-Null` with `[void](...)` throughout `user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1`.
💡 **Why:** Piping to `Out-Null` incurs overhead due to the creation and teardown of the PowerShell pipeline. Casting to `[void]` is functionally equivalent and faster, improving performance without side effects.
✅ **Verification:** Verified by checking the file modifications manually and running PowerShell strict parsing via `[System.Management.Automation.Language.Parser]::ParseInput`. Verified PSScriptAnalyzer syntax passes without ParseErrors, and the code functionally remains identical.
✨ **Result:** A more performant and cleaner script that adheres to PowerShell best practices for discarding output.

---
*PR created automatically by Jules for task [6324135894257617675](https://jules.google.com/task/6324135894257617675) started by @Ven0m0*