### PR TITLE
🧹 Refactor Out-Null to [void] in NvidiaAutoinstall.ps1 for performance

### DIFF
--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -63,23 +63,23 @@ function Edit-Nip {
     if ($settingNameInfo) {
         $newsettingNameInfo.InnerText = $settingNameInfo
     }
-    $newSetting.AppendChild($newsettingNameInfo) | Out-Null
+    [void]$newSetting.AppendChild($newsettingNameInfo)
 
     #create the new setting
     $newsettingID = $nipContent.CreateElement('SettingID')
     $newsettingID.InnerText = $settingId
-    $newSetting.AppendChild($newsettingID) | Out-Null
+    [void]$newSetting.AppendChild($newsettingID)
 
     $newsettingValue = $nipContent.CreateElement('SettingValue')
     $newsettingValue.InnerText = $settingValue
-    $newSetting.AppendChild($newsettingValue) | Out-Null
+    [void]$newSetting.AppendChild($newsettingValue)
 
     $newvalueType = $nipContent.CreateElement('ValueType')
     $newvalueType.InnerText = $valueType
-    $newSetting.AppendChild($newvalueType) | Out-Null
+    [void]$newSetting.AppendChild($newvalueType)
 
     #add new setting to nip
-    $settings.AppendChild($newSetting) | Out-Null
+    [void]$settings.AppendChild($newSetting)
     $nipContent.Save($nipPath)
 
 
@@ -97,11 +97,11 @@ function Run-Trusted([String]$command) {
     $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
     $base64Command = [Convert]::ToBase64String($bytes)
     #change bin to command
-    sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command" | Out-Null
+    [void](sc.exe config TrustedInstaller binPath= "cmd.exe /c powershell.exe -encodedcommand $base64Command")
     #run the command
-    sc.exe start TrustedInstaller | Out-Null
+    [void](sc.exe start TrustedInstaller)
     #set bin back to default
-    sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"" | Out-Null
+    [void](sc.exe config TrustedInstaller binpath= "`"$DefaultBinPath`"")
     Stop-Service -Name TrustedInstaller -Force -ErrorAction SilentlyContinue
 
 }
@@ -190,7 +190,7 @@ if (!(Check-Internet)) {
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
     -Name 'Userinit' -Value `"$currentValue`"
                 "
-                New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force | Out-Null
+                [void](New-Item "$env:TEMP\safemodescript.ps1" -Value $safeModeScript -Force)
                 #create winlogon key
                 $scriptRun = "powershell.exe -nop -ep bypass -f $env:TEMP\safemodescript.ps1"
                 Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'


### PR DESCRIPTION
🎯 **What:** Replaced piping to `Out-Null` with explicit `[void]` casts for object methods and commands across `NvidiaAutoinstall.ps1` (specifically `[void]$object.Method()` for objects and `[void](command)` for external executables).

💡 **Why:** Casting to `[void]` bypasses PowerShell pipeline overhead, improving execution speed and reducing memory allocations during script execution without altering functionality.

✅ **Verification:** 
- Syntactically validated the script (`pwsh -c "Invoke-ScriptAnalyzer"`).
- Confirmed the change introduces no regressions by running the full test suite (`pwsh -c "Invoke-Pester"`), resulting in the same pre-existing 6 passed and 5 failed output as the codebase baseline.
- Peer-reviewed the specific lines (e.g., ensuring cmd.exe executions were wrapped in parentheses to prevent syntax parsing errors).

✨ **Result:** Cleaner, more performant execution of setting assignments and external commands within the NVIDIA configuration script.

---
*PR created automatically by Jules for task [6525209411055040481](https://jules.google.com/task/6525209411055040481) started by @Ven0m0*