### PR TITLE
🧹 Replace Get-WmiObject with Get-CimInstance

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -606,7 +606,7 @@ function Get-MonitorInstances {
 
     if ($ForceRefresh -or -not $script:CachedMonitorInstances) {
         try {
-            $script:CachedMonitorInstances = (Get-WmiObject -Namespace root\wmi -Class WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
+            $script:CachedMonitorInstances = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
         } catch {
             Write-Host "Error retrieving monitor information: $($_.Exception.Message)" -ForegroundColor Red
             $script:CachedMonitorInstances = @()

--- a/Scripts/Network-Tweaker.ps1
+++ b/Scripts/Network-Tweaker.ps1
@@ -2400,7 +2400,7 @@ function Initialize-AdapterUI {
     Write-Host $cb_AdapterNamesCombo.Text
     $Global:NIC_Desc = $cb_AdapterNamesCombo.Text
     $lbl_ndisver.Text = Get-NetAdapter -InterfaceDescription $AdapterName | Select-Object -expand NdisVersion
-    $PhysicalAdapter = Get-WmiObject -Class Win32_NetworkAdapter|Where-Object{$_.Name -like "$NIC_Desc"}
+    $PhysicalAdapter = Get-CimInstance -ClassName Win32_NetworkAdapter|Where-Object{$_.Name -like "$NIC_Desc"}
             $PhysicalAdapterName = $PhysicalAdapter.Name
             $DeviceID = $PhysicalAdapter.DeviceID
                 If([Int32]$DeviceID -lt 10)
@@ -2412,7 +2412,7 @@ function Initialize-AdapterUI {
           $AdapterDeviceNumber = "00"+$DeviceID
             }
 
-        $PnPEntity = Get-WmiObject -Class Win32_PnPEntity -Filter "Name = '$NIC_Desc'"
+        $PnPEntity = Get-CimInstance -ClassName Win32_PnPEntity -Filter "Name = '$NIC_Desc'"
         $Global:EthernetClassGuid = $PnPEntity.ClassGuid
         $Global:EthernetPNPDeviceID = $PnPEntity.PNPDeviceID
         $Global:NetConnectionID = $PhysicalAdapter.NetConnectionID

--- a/Scripts/arc-raiders/ARCRaidersUtility.ps1
+++ b/Scripts/arc-raiders/ARCRaidersUtility.ps1
@@ -206,7 +206,7 @@ function Is-Admin {
 }
 
 function Detect-RTX {
-    $gpu = (Get-WmiObject Win32_VideoController | Select-Object -First 1).Name
+    $gpu = (Get-CimInstance -ClassName Win32_VideoController | Select-Object -First 1).Name
     $supported = $gpu -match 'RTX|Radeon RX [6-9]\d{3}'
     return $supported, ($gpu -replace '^\s+|\s+$','')
 }

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,15 @@
+🧹 Replace Get-WmiObject with Get-CimInstance
+
+🎯 **What:**
+Replaced all occurrences of `Get-WmiObject` with `Get-CimInstance` across the codebase, including `Scripts/Common.ps1`, `Scripts/Network-Tweaker.ps1`, `Scripts/arc-raiders/ARCRaidersUtility.ps1`, and `user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1`.
+
+💡 **Why:**
+`Get-WmiObject` is deprecated and has been superseded by `Get-CimInstance` in newer versions of PowerShell (PowerShell Core / 7+). `Get-CimInstance` offers better performance and cross-platform compatibility by communicating over WS-Man or DCOM, while `Get-WmiObject` is strictly bound to Windows DCOM and is no longer being actively maintained. This change improves script robustness and future-proofs the codebase.
+
+✅ **Verification:**
+- Ran `pwsh -c "Invoke-ScriptAnalyzer"` against all modified files to ensure no syntax or formatting issues were introduced.
+- Ran the test suite via `pwsh -c "Invoke-Pester"` to guarantee no new regressions occurred.
+- Ensured file encodings (UTF-8 with BOM) and line endings (CRLF) were strictly preserved to prevent unintended formatting changes.
+
+✨ **Result:**
+The codebase now exclusively uses `Get-CimInstance` for WMI queries, bringing it inline with modern PowerShell best practices and ensuring better compatibility across different environments.

--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -91,7 +91,7 @@ function Run-Trusted([String]$command) {
 
     Stop-Service -Name TrustedInstaller -Force -ErrorAction SilentlyContinue
     #get bin path to revert later
-    $service = Get-WmiObject -Class Win32_Service -Filter "Name='TrustedInstaller'"
+    $service = Get-CimInstance -ClassName Win32_Service -Filter "Name='TrustedInstaller'"
     $DefaultBinPath = $service.PathName
     #convert command to base64 to avoid errors with spaces
     $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
@@ -788,11 +788,11 @@ if (!(Check-Internet)) {
 
     #get monitor info
     <#
-    $monitors = Get-WmiObject -Namespace root\wmi -Class WmiMonitorID
+    $monitors = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID
     $manufacturerNames = [System.Collections.Generic.List[string]]::new()
-    $soundDevices = Get-WmiObject -Class Win32_SoundDevice
-    $pnpDevices = Get-WmiObject -Class Win32_PnPEntity | Where-Object { $_.PNPDeviceID -ne $null }
-    $videoControllers = Get-WmiObject -Class Win32_VideoController
+    $soundDevices = Get-CimInstance -ClassName Win32_SoundDevice
+    $pnpDevices = Get-CimInstance -ClassName Win32_PnPEntity | Where-Object { $_.PNPDeviceID -ne $null }
+    $videoControllers = Get-CimInstance -ClassName Win32_VideoController
     #>
     $monitors = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID
     $manufacturerNames = [System.Collections.Generic.List[string]]::new()


### PR DESCRIPTION
🎯 **What:** 
Replaced all occurrences of `Get-WmiObject` with `Get-CimInstance` across the codebase, including `Scripts/Common.ps1`, `Scripts/Network-Tweaker.ps1`, `Scripts/arc-raiders/ARCRaidersUtility.ps1`, and `user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1`.

💡 **Why:**
`Get-WmiObject` is deprecated and has been superseded by `Get-CimInstance` in newer versions of PowerShell (PowerShell Core / 7+). `Get-CimInstance` offers better performance and cross-platform compatibility by communicating over WS-Man or DCOM, while `Get-WmiObject` is strictly bound to Windows DCOM and is no longer being actively maintained. This change improves script robustness and future-proofs the codebase.

✅ **Verification:**
- Ran `pwsh -c "Invoke-ScriptAnalyzer"` against all modified files to ensure no syntax or formatting issues were introduced.
- Ran the test suite via `pwsh -c "Invoke-Pester"` to guarantee no new regressions occurred.
- Ensured file encodings (UTF-8 with BOM) and line endings (CRLF) were strictly preserved to prevent unintended formatting changes.

✨ **Result:**
The codebase now exclusively uses `Get-CimInstance` for WMI queries, bringing it inline with modern PowerShell best practices and ensuring better compatibility across different environments.

---
*PR created automatically by Jules for task [16328471841871208095](https://jules.google.com/task/16328471841871208095) started by @Ven0m0*