### PR TITLE
🧹 Refactor Get-WmiObject to Get-CimInstance in Common.ps1

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -606,7 +606,8 @@ function Get-MonitorInstances {
 
     if ($ForceRefresh -or -not $script:CachedMonitorInstances) {
         try {
-            $script:CachedMonitorInstances = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
+            $script:CachedMonitorInstances = (Get-CimInstance -Namespace root\wmi `
+                -ClassName WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
         } catch {
             Write-Host "Error retrieving monitor information: $($_.Exception.Message)" -ForegroundColor Red
             $script:CachedMonitorInstances = @()

--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -606,7 +606,7 @@ function Get-MonitorInstances {
 
     if ($ForceRefresh -or -not $script:CachedMonitorInstances) {
         try {
-            $script:CachedMonitorInstances = (Get-WmiObject -Namespace root\wmi -Class WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
+            $script:CachedMonitorInstances = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID -ErrorAction Stop).InstanceName -replace '_0', ''
         } catch {
             Write-Host "Error retrieving monitor information: $($_.Exception.Message)" -ForegroundColor Red
             $script:CachedMonitorInstances = @()


### PR DESCRIPTION
🎯 **What:** Replaced the usage of `Get-WmiObject` with `Get-CimInstance` in `Scripts/Common.ps1` to retrieve monitor instances.

💡 **Why:** `Get-WmiObject` is deprecated in newer versions of PowerShell and `Get-CimInstance` is the modern, faster, and safer alternative. This ensures the script is robust and conforms to current best practices.

✅ **Verification:** Verified by running `Invoke-ScriptAnalyzer` on `Scripts/Common.ps1`, which passed with zero new warnings/errors. Ran unit tests via `Invoke-Pester -Path Scripts/Common.Tests.ps1` and verified that no regressions were introduced.

✨ **Result:** Improved codebase health and eliminated the use of a deprecated cmdlet without changing the underlying functionality.

---
*PR created automatically by Jules for task [1556167362282685515](https://jules.google.com/task/1556167362282685515) started by @Ven0m0*