### PR TITLE
🧹 Remove commented out code in Network-Tweaker.ps1

### DIFF
--- a/Scripts/Network-Tweaker.ps1
+++ b/Scripts/Network-Tweaker.ps1
@@ -2503,13 +2503,6 @@ function Initialize-AdapterUI {
         $cb_rssqueues.Text = $AdapterQueues
         }
 
-        #$RegistryQueues = Get-ItemPropertyValue -Path "$KeyPath\Ndi\Params\*NumRssQueues" -Name "Default" | Select-Object -expand Default
-        #$PowershellQueues = Get-NetAdapterRss -InterfaceDescription $NIC_Desc | Select-Object -expand NumberOfReceiveQueues
-        #if($RegistryQueues -eq $PowershellQueues){
-        #    Write-Host "NumberOfReceiveQueues is equal."
-        #}else{
-        #    Write-Warning "NumberOfReceiveQueues is not the same. (Powershell and Registry not equal!) Using Registry Value."
-
         #RSS Profiles
         $OSRSSProfiles = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetAdapterRss.Profile].GetEnumValues()
         [void] $cb_rssprofile.Items.AddRange([object[]]@($OSRSSProfiles))


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out (dead) code in `Scripts/Network-Tweaker.ps1` around line 2506.
💡 **Why:** The code was no longer needed and its removal improves the maintainability and readability of the codebase by reducing clutter.
✅ **Verification:** Verified via `git diff` and manual inspection of the script. Confirmed that CRLF line endings and file encoding (no BOM) were preserved.
✨ **Result:** A cleaner script with less technical debt and improved readability.

---
*PR created automatically by Jules for task [14600737118624287490](https://jules.google.com/task/14600737118624287490) started by @Ven0m0*