### PR TITLE
⚡ Optimize WMI filtering for PnPEntity in NvidiaAutoinstall

### DIFF
--- a/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
+++ b/user/.dotfiles/config/nvidia/NvidiaAutoinstall.ps1
@@ -791,13 +791,13 @@ if (!(Check-Internet)) {
     $monitors = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID
     $manufacturerNames = [System.Collections.Generic.List[string]]::new()
     $soundDevices = Get-CimInstance -ClassName Win32_SoundDevice
-    $pnpDevices = Get-CimInstance -ClassName Win32_PnPEntity | Where-Object { $_.PNPDeviceID -ne $null }
+    $pnpDevices = Get-CimInstance -ClassName Win32_PnPEntity -Filter "PNPDeviceID IS NOT NULL"
     $videoControllers = Get-CimInstance -ClassName Win32_VideoController
     #>
     $monitors = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID
     $manufacturerNames = [System.Collections.Generic.List[string]]::new()
     $soundDevices = Get-CimInstance -ClassName Win32_SoundDevice
-    $pnpDevices = Get-CimInstance -ClassName Win32_PnPEntity | Where-Object { $_.PNPDeviceID -ne $null }
+    $pnpDevices = Get-CimInstance -ClassName Win32_PnPEntity -Filter "PNPDeviceID IS NOT NULL"
     $videoControllers = Get-CimInstance -ClassName Win32_VideoController
 
     # Pre-filter NVIDIA Video Controllers


### PR DESCRIPTION
💡 **What:** Replaced the `Get-CimInstance ... | Where-Object` pipeline with `Get-CimInstance ... -Filter "PNPDeviceID IS NOT NULL"` for `Win32_PnPEntity`.

🎯 **Why:** Filtering at the WMI provider level avoids transferring unneeded objects across the WMI boundary and processing them in PowerShell, which significantly speeds up execution.

📊 **Measured Improvement:** The `pwsh` binary wasn't readily available to run `Measure-Command` in this Linux-based sandbox. However, provider-side filtering is universally recognized as dramatically faster than client-side pipeline filtering for WMI queries.

---
*PR created automatically by Jules for task [14909923891614953719](https://jules.google.com/task/14909923891614953719) started by @Ven0m0*