### PR TITLE
🧹 Cleanup Network-Tweaker.ps1 and Fix CI Format Check

### DIFF
--- a/.github/workflows/ps-format.yml
+++ b/.github/workflows/ps-format.yml
@@ -67,10 +67,7 @@ jobs:
             $bytes = [System.IO.File]::ReadAllBytes($file)
             $content = [System.IO.File]::ReadAllText($file, [System.Text.UTF8Encoding]::new($true))
 
-            # Remove BOM from content for processing
-            if ($bytes.Count -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
-              $content = $content.Substring(1)
-            }
+            # ReadAllText with UTF8Encoding(true) already handles the BOM correctly.
 
              $lines = $content -split "\r?\n"
 

--- a/Scripts/Network-Tweaker.ps1
+++ b/Scripts/Network-Tweaker.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .NAME
     Tweaking Adapter
 #>
@@ -2473,18 +2473,18 @@ function Initialize-AdapterUI {
     $IPv6_2 = (Get-ItemPropertyValue -Path "REGISTRY::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" -Name "EnableICSIPv6")
 
     if ($IPv6_1 -eq "255" -and $IPv6_2 -eq "0"){
-         Write-Warning  "IPv6 is Disabled by Registry."  -ForegroundColor Green
-         $cb_IPv6.Checked = $False
-         $cb_IPv6.Enabled = $False
-         $cb_IPv6.Visible = $False
-         $cb_IPv4.Checked = $True
-         $Global:AddressFamily = "IPv4"
-         }else{
+        Write-Warning  "IPv6 is Disabled by Registry."  -ForegroundColor Green
+        $cb_IPv6.Checked = $False
+        $cb_IPv6.Enabled = $False
+        $cb_IPv6.Visible = $False
+        $cb_IPv4.Checked = $True
+        $Global:AddressFamily = "IPv4"
+        }else{
           Write-Warning  "IPv4/IPv6 is Enabled by Registry. Selecting IPv4 as Default for AddressFamily"  -ForegroundColor Green
           $cb_IPv4.Checked = $true
           $cb_IPv6.Checked = $false
           $Global:AddressFamily = "IPv4"
-         }
+        }
 
     #RSS Queues
     #Query Available RSSQueues
@@ -2502,13 +2502,6 @@ function Initialize-AdapterUI {
         $AdapterQueues = Get-ItemProperty -Path "$KeyPath\Ndi\Params\*NumRssQueues" -Name "Default" | Select-Object -expand Default
         $cb_rssqueues.Text = $AdapterQueues
         }
-
-        #$RegistryQueues = Get-ItemPropertyValue -Path "$KeyPath\Ndi\Params\*NumRssQueues" -Name "Default" | Select-Object -expand Default
-        #$PowershellQueues = Get-NetAdapterRss -InterfaceDescription $NIC_Desc | Select-Object -expand NumberOfReceiveQueues
-        #if($RegistryQueues -eq $PowershellQueues){
-        #    Write-Host "NumberOfReceiveQueues is equal."
-        #}else{
-        #    Write-Warning "NumberOfReceiveQueues is not the same. (Powershell and Registry not equal!) Using Registry Value."
 
         #RSS Profiles
         $OSRSSProfiles = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetAdapterRss.Profile].GetEnumValues()


### PR DESCRIPTION
🎯 **What:** Removed dead code and improved formatting in `Scripts/Network-Tweaker.ps1`, while fixing a bug in the CI formatting workflow.

💡 **Why:** 
- The dead code was cluttering the script and had no purpose.
- Indentation was inconsistent (9 spaces instead of 8), triggering CI failures.
- The script lacked a UTF-8 BOM, which is required by the repository's CI checks.
- The CI workflow bug (`Substring(1)` on BOM files) was corrupting the first character of scripts during the format check, leading to cascading syntax errors.

✅ **Verification:** 
- Verified dead code removal and indentation via `cat -n`.
- Confirmed BOM and line endings (CRLF) using `od` and `file`.
- Verified the CI workflow fix by inspecting the updated yaml logic.

✨ **Result:** A cleaner, better-formatted script that satisfies CI requirements and a more robust CI formatting check.

---
*PR created automatically by Jules for task [14600737118624287490](https://jules.google.com/task/14600737118624287490) started by @Ven0m0*