### PR TITLE
🔒 Fix overly permissive PowerShell ExecutionPolicy

### DIFF
--- a/Scripts/allow-scripts.cmd
+++ b/Scripts/allow-scripts.cmd
@@ -26,10 +26,10 @@
 
 cls
 :: allow double click powershell scripts
-reg add "HKCR\Applications\powershell.exe\shell\open\command" /ve /t REG_SZ /d "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -ExecutionPolicy unrestricted -File \"%%1\"" /f >nul 2>&1
+reg add "HKCR\Applications\powershell.exe\shell\open\command" /ve /t REG_SZ /d "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -ExecutionPolicy RemoteSigned -File \"%%1\"" /f >nul 2>&1
 :: allow powershell scripts
-reg add "HKCU\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v "ExecutionPolicy" /t REG_SZ /d "Unrestricted" /f >nul 2>&1
-reg add "HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v "ExecutionPolicy" /t REG_SZ /d "Unrestricted" /f >nul 2>&1
+reg add "HKCU\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v "ExecutionPolicy" /t REG_SZ /d "RemoteSigned" /f >nul 2>&1
+reg add "HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v "ExecutionPolicy" /t REG_SZ /d "RemoteSigned" /f >nul 2>&1
 :: unblock all files in current directory
 cd %~dp0
 powershell -Command "Get-ChildItem -Path $PSScriptRoot -Recurse | Unblock-File"

--- a/Scripts/allow-scripts.ps1
+++ b/Scripts/allow-scripts.ps1
@@ -11,20 +11,20 @@ Initialize-ConsoleUI -Title "PowerShell Script Manager (Administrator)"
 function Enable-ScriptExecution {
   <#
   .SYNOPSIS
-    Sets execution policy to Unrestricted and unblocks scripts in this directory.
+    Sets execution policy to RemoteSigned and unblocks scripts in this directory.
   #>
   Write-Host "Enabling PowerShell scripts..." -ForegroundColor Cyan
   Write-Host ""
 
   Write-Host "[1/3] Configuring PowerShell file associations..."
   Set-RegistryValue -Path 'HKCR\Applications\powershell.exe\shell\open\command' -Name '' `
-    -Type REG_SZ -Data 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -ExecutionPolicy Unrestricted -File "%1"'
+    -Type REG_SZ -Data 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -ExecutionPolicy RemoteSigned -File "%1"'
 
-  Write-Host "[2/3] Setting execution policy to Unrestricted..."
+  Write-Host "[2/3] Setting execution policy to RemoteSigned..."
   Set-RegistryValue -Path 'HKCU\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell' `
-    -Name 'ExecutionPolicy' -Type REG_SZ -Data 'Unrestricted'
+    -Name 'ExecutionPolicy' -Type REG_SZ -Data 'RemoteSigned'
   Set-RegistryValue -Path 'HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell' `
-    -Name 'ExecutionPolicy' -Type REG_SZ -Data 'Unrestricted'
+    -Name 'ExecutionPolicy' -Type REG_SZ -Data 'RemoteSigned'
 
   Write-Host "[3/3] Unblocking all scripts in current directory..."
   Get-ChildItem -Path $PSScriptRoot -Recurse -ErrorAction SilentlyContinue |
@@ -33,7 +33,7 @@ function Enable-ScriptExecution {
   Write-Host ""
   Write-Host "PowerShell Scripts Enabled!" -ForegroundColor Green
   Write-Host "  - Scripts can now be run by double-clicking" -ForegroundColor Gray
-  Write-Host "  - Execution policy set to Unrestricted" -ForegroundColor Gray
+  Write-Host "  - Execution policy set to RemoteSigned" -ForegroundColor Gray
   Write-Host "  - All files in this directory unblocked" -ForegroundColor Gray
 }
 

--- a/Scripts/auto/autounattend.xml
+++ b/Scripts/auto/autounattend.xml
@@ -118,7 +118,7 @@
 				</RunSynchronousCommand>
 				<RunSynchronousCommand wcm:action="add">
 					<Order>2</Order>
-					<Path>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "Unrestricted" -NoProfile -File "C:\Windows\Setup\Scripts\Specialize.ps1"</Path>
+					<Path>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "RemoteSigned" -NoProfile -File "C:\Windows\Setup\Scripts\Specialize.ps1"</Path>
 				</RunSynchronousCommand>
 				<RunSynchronousCommand wcm:action="add">
 					<Order>3</Order>
@@ -126,7 +126,7 @@
 				</RunSynchronousCommand>
 				<RunSynchronousCommand wcm:action="add">
 					<Order>4</Order>
-					<Path>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "Unrestricted" -NoProfile -File "C:\Windows\Setup\Scripts\DefaultUser.ps1"</Path>
+					<Path>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "RemoteSigned" -NoProfile -File "C:\Windows\Setup\Scripts\DefaultUser.ps1"</Path>
 				</RunSynchronousCommand>
 				<RunSynchronousCommand wcm:action="add">
 					<Order>5</Order>
@@ -176,7 +176,7 @@
 			<FirstLogonCommands>
 				<SynchronousCommand wcm:action="add">
 					<Order>1</Order>
-					<CommandLine>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "Unrestricted" -NoProfile -File "C:\Windows\Setup\Scripts\FirstLogon.ps1"</CommandLine>
+					<CommandLine>powershell.exe -WindowStyle "Hidden" -ExecutionPolicy "RemoteSigned" -NoProfile -File "C:\Windows\Setup\Scripts\FirstLogon.ps1"</CommandLine>
 				</SynchronousCommand>
 			</FirstLogonCommands>
 		</component>
@@ -751,7 +751,7 @@ $scripts = @(
 		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\DWM" /v ColorPrevalence /t REG_DWORD /d 0 /f;
 	};
 	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /v "UnattendedSetup" /t REG_SZ /d "powershell.exe -WindowStyle \""Hidden\"" -ExecutionPolicy \""Unrestricted\"" -NoProfile -File \""C:\Windows\Setup\Scripts\UserOnce.ps1\""" /f;
+		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /v "UnattendedSetup" /t REG_SZ /d "powershell.exe -WindowStyle \""Hidden\"" -ExecutionPolicy \""RemoteSigned\"" -NoProfile -File \""C:\Windows\Setup\Scripts\UserOnce.ps1\""" /f;
 	};
 );
 

--- a/Scripts/shell-setup.ps1
+++ b/Scripts/shell-setup.ps1
@@ -3,7 +3,7 @@
   Initialize custom PowerShell + tooling environment (Scoop, Winget, Choco, apps, custom downloads).
 .NOTES
   Requires Windows, PowerShell 5+; will elevate for certain steps.
-  ExecutionPolicy for CurrentUser will be set to Unrestricted on first run.
+  ExecutionPolicy for CurrentUser will be set to RemoteSigned on first run.
 #>
 [CmdletBinding()]
 param()
@@ -135,14 +135,14 @@ function Enable-Bucket {
   }
 }
 
-# ExecutionPolicy: CurrentUser -> Unrestricted
-if ((Get-ExecutionPolicy -Scope CurrentUser) -notcontains "Unrestricted") {
+# ExecutionPolicy: CurrentUser -> RemoteSigned
+if ((Get-ExecutionPolicy -Scope CurrentUser) -notcontains "RemoteSigned") {
   Write-Verbose "Setting Execution Policy for Current User..."
   Run-Elevated -FilePath "PowerShell" -ArgumentList "Set-ExecutionPolicy",
     "-Scope",
     "CurrentUser",
     "-ExecutionPolicy",
-    "Unrestricted",
+    "RemoteSigned",
     "-Force"
   Write-Output "Restart/Re-Run script required."
   Start-Sleep -Seconds 10

--- a/user/.dotfiles/config/nvidia/nvidia-telemetry-cleanup.cmd
+++ b/user/.dotfiles/config/nvidia/nvidia-telemetry-cleanup.cmd
@@ -77,7 +77,7 @@ echo.
 :: ============================================================
 echo [4/6] Removing NVIDIA telemetry files...
 
-PowerShell -ExecutionPolicy Unrestricted -NoProfile -Command ^
+PowerShell -ExecutionPolicy RemoteSigned -NoProfile -Command ^
 "$paths = @('%PROGRAMFILES(X86)%\NVIDIA Corporation\NvTelemetry\*', '%PROGRAMFILES%\NVIDIA Corporation\NvTelemetry\*', '%SYSTEMROOT%\System32\DriverStore\FileRepository\NvTelemetry*.dll'); " ^
 "foreach ($pathPattern in $paths) { " ^
 "  $expandedPath = [System.Environment]::ExpandEnvironmentVariables($pathPattern); " ^


### PR DESCRIPTION
🎯 **What:** The PowerShell `ExecutionPolicy` was previously being set to `Unrestricted` globally or for the CurrentUser across multiple scripts and configuration files, including `shell-setup.ps1`, `allow-scripts.ps1`, `allow-scripts.cmd`, `autounattend.xml`, and `nvidia-telemetry-cleanup.cmd`. These have all been changed to `RemoteSigned`.

⚠️ **Risk:** The `Unrestricted` execution policy loads all configuration files and runs all scripts without requiring them to be digitally signed, leaving the user vulnerable to remote code execution (RCE) via downloaded or shared malicious scripts. This could result in system compromise or unauthorized data access.

🛡️ **Solution:** The policy was updated to `RemoteSigned` in all places. `RemoteSigned` provides a better balance of security and usability. It allows running locally created scripts without needing a signature, but requires any scripts downloaded from the internet to be digitally signed by a trusted publisher before execution.

---
*PR created automatically by Jules for task [8499393654618756987](https://jules.google.com/task/8499393654618756987) started by @Ven0m0*