### PR TITLE
🧪 Add Pester tests for system-maintenance.ps1

### DIFF
--- a/.github/workflows/ps-format.yml
+++ b/.github/workflows/ps-format.yml
@@ -49,7 +49,7 @@ jobs:
             Write-Host "No specific changed files detected. Skipping legacy full-repo check."
             $files = @()
           }
-          "files=$($files -join ',')") | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8BOM
+          "files=$($files -join ',')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8BOM
           Write-Host "Changed files: $($files -join ', ')"
 
       - name: Run formatting check

--- a/Scripts/system-maintenance.Tests.ps1
+++ b/Scripts/system-maintenance.Tests.ps1
@@ -1,0 +1,58 @@
+﻿BeforeAll {
+    Import-Module Pester -MinimumVersion 5.0
+    # Dot-source with skip flags so it doesn't execute maintenance during import
+    . "$PSScriptRoot/system-maintenance.ps1" -NoDefrag -NoMsi
+}
+
+Describe "Invoke-Defrag" {
+    It "Should run correct commands for target volume" {
+        Mock Invoke-Step {}
+        Mock Write-Verbose {}
+
+        Invoke-Defrag -TargetVolume "D:"
+
+        Should -Invoke Invoke-Step -Times 5
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag D: /O" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag D: /L" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag D: /X" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag D: /G" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag D: /B" } -Times 1
+    }
+
+    It "Should run correct commands for all volumes" {
+        Mock Invoke-Step {}
+        Mock Write-Verbose {}
+
+        Invoke-Defrag -All
+
+        Should -Invoke Invoke-Step -Times 3
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag /C" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag /C /O" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -eq "defrag /C /L" } -Times 1
+    }
+}
+
+Describe "Invoke-MsiCleanup" {
+    It "Should throw error if directory is missing" {
+        Mock Test-Path { return $false }
+
+        { Invoke-MsiCleanup -Root "C:\InvalidPath" } | Should -Throw "MSI Afterburner not found at: C:\InvalidPath"
+    }
+
+    It "Should perform cleanup commands if directory exists" {
+        Mock Test-Path { return $true }
+        Mock Invoke-Step {}
+        Mock Write-Verbose {}
+
+        Invoke-MsiCleanup -Root "C:\MSI"
+
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^copy /Y" } -Times 3
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^rmdir /S /Q .*Skins" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^rmdir /S /Q .*Localization" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^rmdir /S /Q .*Doc" } -Times 2
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^mkdir " } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^move /Y" } -Times 3
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^rmdir /S /Q .*SDK" } -Times 1
+        Should -Invoke Invoke-Step -ParameterFilter { $CommandLine -match "^del /F /Q .*ReadMe.lnk" } -Times 1
+    }
+}


### PR DESCRIPTION
🎯 **What:** 
Added a missing Pester test file (`Scripts/system-maintenance.Tests.ps1`) for `system-maintenance.ps1` to establish a testing baseline and support test-driven development.

📊 **Coverage:** 
- `Invoke-Defrag`: Tested logic for specific target volumes and the `-All` volumes flag, validating command line flags sent to `defrag.exe`.
- `Invoke-MsiCleanup`: Tested invalid missing path errors and simulated cleanup operations using mocked built-in commands (like `Test-Path` and `Invoke-Step`) to verify folder/file copies and deletions.
- Tests load the script with `-NoDefrag` and `-NoMsi` suppression flags to safely prevent real environment modifications during test suite execution.

✨ **Result:** 
Significant improvement in script safety and coverage, allowing the maintenance payload to be confidently refactored without breaking underlying system commands.

---
*PR created automatically by Jules for task [8337831640933272059](https://jules.google.com/task/8337831640933272059) started by @Ven0m0*