### PR TITLE
🧪 Add test file for Install-Packages.ps1

### DIFF
--- a/Scripts/Install-Packages.Tests.ps1
+++ b/Scripts/Install-Packages.Tests.ps1
@@ -1,0 +1,91 @@
+BeforeAll {
+    Import-Module Pester -MinimumVersion 5.0
+}
+
+Describe "Install-Packages" {
+    BeforeAll {
+        function winget {}
+        function scoop {}
+        function choco {}
+        function DISM {}
+        function fsutil.exe {}
+        function tzutil.exe {}
+        function Set-TimeZone {}
+        function Set-Culture {}
+        . "$PSScriptRoot/Install-Packages.ps1"
+    }
+
+    Context "Initialization" {
+        It "Should load the module and functions without execution" {
+            Get-Command Start-InstallPackages -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "Parameters functionality" {
+        BeforeEach {
+            $script:isAdminOverride = $true
+            Mock Write-Host {}
+            Mock Write-Warning {}
+            Mock Invoke-RestMethod {}
+            Mock Remove-Item {}
+            Mock Set-ExecutionPolicy {}
+            Mock Set-ItemProperty {}
+            Mock New-Item {}
+            Mock Test-Path { return $true }
+
+            Mock winget {}
+            Mock scoop {}
+            Mock choco {}
+            Mock DISM {}
+            Mock fsutil.exe {}
+            Mock tzutil.exe {}
+            Mock Set-TimeZone {}
+            Mock Set-Culture {}
+
+            # The script uses $env:SystemDrive. On Linux, this is null.
+            # So $env:SystemDrive.TrimEnd('\') fails with "You cannot call a method on a null-valued expression."
+            $env:SystemDrive = "C:\"
+        }
+
+        AfterEach {
+            $script:isAdminOverride = $null
+            $env:SystemDrive = $null
+        }
+
+        It "Should bypass winget when SkipWinget is provided" {
+            Start-InstallPackages -SkipWinget -SkipScoop -SkipChoco -SkipSystemFeatures -ApplyPostInstall:$false
+            Assert-MockCalled winget -Times 0
+        }
+
+        It "Should bypass scoop when SkipScoop is provided" {
+            Start-InstallPackages -SkipScoop -ApplyPostInstall:$false
+            Assert-MockCalled scoop -Times 0
+            Assert-MockCalled Invoke-RestMethod -Times 0 -ParameterFilter { $Uri -match 'scoop' }
+        }
+
+        It "Should bypass choco when SkipChoco is provided" {
+            Start-InstallPackages -SkipChoco -ApplyPostInstall:$false
+            Assert-MockCalled choco -Times 0
+            Assert-MockCalled Invoke-RestMethod -Times 0 -ParameterFilter { $Uri -match 'chocolatey' }
+        }
+
+        It "Should bypass system features when SkipSystemFeatures is provided" {
+            Start-InstallPackages -SkipSystemFeatures -ApplyPostInstall:$false
+            Assert-MockCalled DISM -Times 0
+        }
+
+        It "Should not apply post-install when ApplyPostInstall is missing" {
+            Start-InstallPackages -SkipWinget -SkipScoop -SkipChoco -SkipSystemFeatures
+            Assert-MockCalled Set-TimeZone -Times 0
+            Assert-MockCalled Set-Culture -Times 0
+            Assert-MockCalled fsutil.exe -Times 0
+        }
+
+        It "Should apply post-install when ApplyPostInstall is provided" {
+            Start-InstallPackages -SkipWinget -SkipScoop -SkipChoco -SkipSystemFeatures -ApplyPostInstall
+            Assert-MockCalled Set-TimeZone -Times 1
+            Assert-MockCalled Set-Culture -Times 1
+            Assert-MockCalled fsutil.exe -Times 2
+        }
+    }
+}

--- a/Scripts/Install-Packages.ps1
+++ b/Scripts/Install-Packages.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 <#
 .SYNOPSIS
     Installs all required packages and tools for the Windows development environment.
@@ -44,350 +44,379 @@ param(
     [int]$PostInstallGeoId = 94
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
 
-$script:StartTime = Get-Date
-$script:Results = @{}
-
-function Write-Status {
-    param([string]$Message, [string]$Status = 'INFO')
-    $color = switch ($Status) { 'OK' { 'Green' } 'FAIL' { 'Red' } 'SKIP' { 'Yellow' } 'RUNNING' { 'Cyan' } default { 'White' } }
-    Write-Host "  [$Status] $Message" -ForegroundColor $color
-    $script:Results[$Message] = $Status
-}
-
-function Invoke-Operation {
-    param([string]$Name, [scriptblock]$Action, [string]$SuccessStatus = 'OK')
-    Write-Status "$Name" -Status 'RUNNING'
-    try { & $Action; Write-Status "$Name" -Status $SuccessStatus; return $true }
-    catch { Write-Status "$Name - $($_.Exception.Message)" -Status 'FAIL'; return $false }
-}
-
-function Install-WingetTool {
-    param([string]$Id, [string]$Name)
-    if ($PSCmdlet.ShouldProcess($Name, 'Install via winget')) {
-        Write-Host "  Installing $Name..." -ForegroundColor Gray -NoNewline
-        try {
-            winget install --id $Id --silent --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
-            $ec = $LASTEXITCODE
-            if ($ec -eq 0 -or $ec -eq -1978335189) {
-                Write-Host " [OK]" -ForegroundColor Green
-            } else {
-                Write-Host ""
-                Write-Warning "  [WARN] $Name - winget exit code: $ec"
-            }
-        } catch {
-            Write-Host ""
-            Write-Warning "  [WARN] $Name - $_"
-        }
-    }
-}
-
-# ============================================================================
-# Phase 1: Prerequisites check and installation
-# ============================================================================
-Write-Host '[1/7] Checking prerequisites...' -ForegroundColor Cyan
-
-# Check if running as admin for system-level operations
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
-    [Security.Principal.WindowsBuiltInRole]::Administrator
-)
-
-if (-not $isAdmin) {
-    Write-Host '  [REQUIRED] Some operations require administrator privileges.' -ForegroundColor Yellow
-    Write-Host '  Relaunching as administrator...' -ForegroundColor Yellow
-    $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
-    $shell = if ($pwshCmd) { $pwshCmd.Source } else { 'PowerShell.exe' }
-    $argList = "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`""
-    foreach ($p in 'SkipWinget','SkipScoop','SkipChoco','SkipSystemFeatures','ApplyPostInstall') {
-        if ((Get-Variable $p -ErrorAction SilentlyContinue).Value) { $argList += " -$p" }
-    }
-    Start-Process $shell -ArgumentList $argList -Verb RunAs
-    exit 0
-}
-
-# Set execution policy
-try {
-    if ($PSCmdlet.ShouldProcess('CurrentUser execution policy', 'Set to RemoteSigned')) {
-        Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-        Write-Status 'Execution policy set to RemoteSigned' -Status 'OK'
-    }
-} catch {
-    Write-Warning "  Could not set execution policy: $_"
-}
-
-# Check winget availability
-if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-    Write-Status 'winget not found. Install from https://aka.ms/getwinget' -Status 'FAIL'
-    exit 1
-}
-Write-Status 'winget is available' -Status 'OK'
-
-# ============================================================================
-# Phase 2: Install core tools via winget
-# ============================================================================
-if (-not $SkipWinget) {
-    Write-Host ''
-    Write-Host '[2/7] Installing core tools via winget...' -ForegroundColor Cyan
-
-    $coreTools = @(
-        @{ id = 'Git.Git';                    name = 'Git' },
-        @{ id = 'Microsoft.PowerShell';       name = 'PowerShell 7+' },
-        @{ id = 'Microsoft.WindowsTerminal';  name = 'Windows Terminal' },
-        @{ id = 'Microsoft.VisualStudioCode'; name = 'VS Code' }
+function Start-InstallPackages {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [switch]$SkipWinget,
+        [switch]$SkipScoop,
+        [switch]$SkipChoco,
+        [switch]$SkipSystemFeatures,
+        [switch]$ApplyPostInstall,
+        [string]$PostInstallComputerName = 'PC',
+        [string]$PostInstallTimeZone = 'W. Europe Standard Time',
+        [string]$PostInstallInputLocale = 'en-US',
+        [int]$PostInstallGeoId = 94
     )
 
-    foreach ($tool in $coreTools) {
-        Install-WingetTool -Id $tool.id -Name $tool.name
-    }
-}
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+    $ProgressPreference = 'SilentlyContinue'
 
-# ============================================================================
-# Phase 3: Install runtimes via winget
-# ============================================================================
-if (-not $SkipWinget) {
-    Write-Host ''
-    Write-Host '[3/7] Installing runtimes via winget...' -ForegroundColor Cyan
+    $script:StartTime = Get-Date
+    $script:Results = @{}
 
-    $runtimes = @(
-        'Microsoft.VCRedist.2015+.x64',
-        'Microsoft.DotNet.DesktopRuntime.9',
-        'Microsoft.DotNet.DesktopRuntime.8',
-        'Microsoft.DotNet.DesktopRuntime.7',
-        'Oracle.JavaRuntimeEnvironment',
-        'EclipseAdoptium.Temurin.25.JRE'
-    )
-
-    foreach ($pkg in $runtimes) {
-        Install-WingetTool -Id $pkg -Name $pkg
-    }
-}
-
-# ============================================================================
-# Phase 4: Install development tools and utilities via winget
-# ============================================================================
-if (-not $SkipWinget) {
-    Write-Host ''
-    Write-Host '[4/7] Installing development tools via winget...' -ForegroundColor Cyan
-
-    $devTools = @(
-        'OpenJS.NodeJS',
-        'Python.Python.3.13',
-        'GitHub.cli',
-        'Notepad++.Notepad++',
-        'VSCodium.VSCodium',
-        'Rustlang.Rust.MSVC',
-        'astral-sh.uv',
-        'Oven-sh.Bun',
-        'jdx.mise',
-        'topgrade-rs.topgrade',
-        'eza-community.eza',
-        'BurntSushi.ripgrep.MSVC',
-        'sharkdp.fd',
-        'sharkdp.bat',
-        'Starship.Starship',
-        'JanDeDobbeleer.OhMyPosh',
-        '7zip.7zip',
-        'VideoLAN.VLC',
-        'OBSProject.OBSStudio',
-        'MartiCliment.UniGetUI',
-        'Chocolatey.Chocolatey'
-    )
-
-    foreach ($pkg in $devTools) {
-        Install-WingetTool -Id $pkg -Name $pkg
-    }
-}
-
-# ============================================================================
-# Phase 5: Scoop installation and packages
-# ============================================================================
-if (-not $SkipScoop) {
-    Write-Host ''
-    Write-Host '[5/7] Setting up Scoop...' -ForegroundColor Cyan
-
-    # Install Scoop if not present
-    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
-        Write-Status 'Installing Scoop...' -Status 'RUNNING'
-        try {
-            $scoopInstaller = Join-Path $env:TEMP ("install-scoop-{0}.ps1" -f [System.Guid]::NewGuid().ToString('N'))
-            Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
-            & $scoopInstaller
-            Remove-Item $scoopInstaller -Force -ErrorAction SilentlyContinue
-            Write-Status 'Scoop installed' -Status 'OK'
-        } catch {
-            Write-Status "Scoop installation failed: $_" -Status 'FAIL'
-        }
-    } else {
-        Write-Status 'Scoop already installed' -Status 'OK'
+    function Write-Status {
+        param([string]$Message, [string]$Status = 'INFO')
+        $color = switch ($Status) { 'OK' { 'Green' } 'FAIL' { 'Red' } 'SKIP' { 'Yellow' } 'RUNNING' { 'Cyan' } default { 'White' } }
+        Write-Host "  [$Status] $Message" -ForegroundColor $color
+        $script:Results[$Message] = $Status
     }
 
-    # Add Scoop buckets
-    if (Get-Command scoop -ErrorAction SilentlyContinue) {
-        $scoopBuckets = @('extras', 'nerd-fonts', 'java', 'nirsoft')
-        foreach ($bucket in $scoopBuckets) {
+    function Invoke-Operation {
+        param([string]$Name, [scriptblock]$Action, [string]$SuccessStatus = 'OK')
+        Write-Status "$Name" -Status 'RUNNING'
+        try { & $Action; Write-Status "$Name" -Status $SuccessStatus; return $true }
+        catch { Write-Status "$Name - $($_.Exception.Message)" -Status 'FAIL'; return $false }
+    }
+
+    function Install-WingetTool {
+        param([string]$Id, [string]$Name)
+        if ($PSCmdlet.ShouldProcess($Name, 'Install via winget')) {
+            Write-Host "  Installing $Name..." -ForegroundColor Gray -NoNewline
             try {
-                scoop bucket add $bucket 2>$null
-                Write-Status "Scoop bucket '$bucket' added" -Status 'OK'
+                winget install --id $Id --silent --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+                $ec = $LASTEXITCODE
+                if ($ec -eq 0 -or $ec -eq -1978335189) {
+                    Write-Host " [OK]" -ForegroundColor Green
+                } else {
+                    Write-Host ""
+                    Write-Warning "  [WARN] $Name - winget exit code: $ec"
+                }
             } catch {
-                Write-Status "Scoop bucket '$bucket' (may already exist)" -Status 'SKIP'
+                Write-Host ""
+                Write-Warning "  [WARN] $Name - $_"
+            }
+        }
+    }
+
+    # ============================================================================
+    # Phase 1: Prerequisites check and installation
+    # ============================================================================
+    Write-Host '[1/7] Checking prerequisites...' -ForegroundColor Cyan
+
+    # Check if running as admin for system-level operations
+    if ($null -eq $script:isAdminOverride) {
+        $isAdmin = $false
+        try {
+            $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator
+            )
+        } catch {}
+    } else {
+        $isAdmin = $script:isAdminOverride
+    }
+
+    if (-not $isAdmin) {
+        Write-Host '  [REQUIRED] Some operations require administrator privileges.' -ForegroundColor Yellow
+        Write-Host '  Relaunching as administrator...' -ForegroundColor Yellow
+        $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+        $shell = if ($pwshCmd) { $pwshCmd.Source } else { 'PowerShell.exe' }
+        $argList = "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`""
+        foreach ($p in 'SkipWinget','SkipScoop','SkipChoco','SkipSystemFeatures','ApplyPostInstall') {
+            if ((Get-Variable $p -ErrorAction SilentlyContinue).Value) { $argList += " -$p" }
+        }
+        try { Start-Process $shell -ArgumentList $argList -Verb RunAs } catch {}
+        return
+    }
+
+    # Set execution policy
+    try {
+        if ($PSCmdlet.ShouldProcess('CurrentUser execution policy', 'Set to RemoteSigned')) {
+            Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+            Write-Status 'Execution policy set to RemoteSigned' -Status 'OK'
+        }
+    } catch {
+        Write-Warning "  Could not set execution policy: $_"
+    }
+
+    # Check winget availability
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Status 'winget not found. Install from https://aka.ms/getwinget' -Status 'FAIL'
+        exit 1
+    }
+    Write-Status 'winget is available' -Status 'OK'
+
+    # ============================================================================
+    # Phase 2: Install core tools via winget
+    # ============================================================================
+    if (-not $SkipWinget) {
+        Write-Host ''
+        Write-Host '[2/7] Installing core tools via winget...' -ForegroundColor Cyan
+
+        $coreTools = @(
+            @{ id = 'Git.Git';                    name = 'Git' },
+            @{ id = 'Microsoft.PowerShell';       name = 'PowerShell 7+' },
+            @{ id = 'Microsoft.WindowsTerminal';  name = 'Windows Terminal' },
+            @{ id = 'Microsoft.VisualStudioCode'; name = 'VS Code' }
+        )
+
+        foreach ($tool in $coreTools) {
+            Install-WingetTool -Id $tool.id -Name $tool.name
+        }
+    }
+
+    # ============================================================================
+    # Phase 3: Install runtimes via winget
+    # ============================================================================
+    if (-not $SkipWinget) {
+        Write-Host ''
+        Write-Host '[3/7] Installing runtimes via winget...' -ForegroundColor Cyan
+
+        $runtimes = @(
+            'Microsoft.VCRedist.2015+.x64',
+            'Microsoft.DotNet.DesktopRuntime.9',
+            'Microsoft.DotNet.DesktopRuntime.8',
+            'Microsoft.DotNet.DesktopRuntime.7',
+            'Oracle.JavaRuntimeEnvironment',
+            'EclipseAdoptium.Temurin.25.JRE'
+        )
+
+        foreach ($pkg in $runtimes) {
+            Install-WingetTool -Id $pkg -Name $pkg
+        }
+    }
+
+    # ============================================================================
+    # Phase 4: Install development tools and utilities via winget
+    # ============================================================================
+    if (-not $SkipWinget) {
+        Write-Host ''
+        Write-Host '[4/7] Installing development tools via winget...' -ForegroundColor Cyan
+
+        $devTools = @(
+            'OpenJS.NodeJS',
+            'Python.Python.3.13',
+            'GitHub.cli',
+            'Notepad++.Notepad++',
+            'VSCodium.VSCodium',
+            'Rustlang.Rust.MSVC',
+            'astral-sh.uv',
+            'Oven-sh.Bun',
+            'jdx.mise',
+            'topgrade-rs.topgrade',
+            'eza-community.eza',
+            'BurntSushi.ripgrep.MSVC',
+            'sharkdp.fd',
+            'sharkdp.bat',
+            'Starship.Starship',
+            'JanDeDobbeleer.OhMyPosh',
+            '7zip.7zip',
+            'VideoLAN.VLC',
+            'OBSProject.OBSStudio',
+            'MartiCliment.UniGetUI',
+            'Chocolatey.Chocolatey'
+        )
+
+        foreach ($pkg in $devTools) {
+            Install-WingetTool -Id $pkg -Name $pkg
+        }
+    }
+
+    # ============================================================================
+    # Phase 5: Scoop installation and packages
+    # ============================================================================
+    if (-not $SkipScoop) {
+        Write-Host ''
+        Write-Host '[5/7] Setting up Scoop...' -ForegroundColor Cyan
+
+        # Install Scoop if not present
+        if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+            Write-Status 'Installing Scoop...' -Status 'RUNNING'
+            try {
+                $scoopInstaller = Join-Path $env:TEMP ("install-scoop-{0}.ps1" -f [System.Guid]::NewGuid().ToString('N'))
+                Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
+                & $scoopInstaller
+                Remove-Item $scoopInstaller -Force -ErrorAction SilentlyContinue
+                Write-Status 'Scoop installed' -Status 'OK'
+            } catch {
+                Write-Status "Scoop installation failed: $_" -Status 'FAIL'
+            }
+        } else {
+            Write-Status 'Scoop already installed' -Status 'OK'
+        }
+
+        # Add Scoop buckets
+        if (Get-Command scoop -ErrorAction SilentlyContinue) {
+            $scoopBuckets = @('extras', 'nerd-fonts', 'java', 'nirsoft')
+            foreach ($bucket in $scoopBuckets) {
+                try {
+                    scoop bucket add $bucket 2>$null
+                    Write-Status "Scoop bucket '$bucket' added" -Status 'OK'
+                } catch {
+                    Write-Status "Scoop bucket '$bucket' (may already exist)" -Status 'SKIP'
+                }
+            }
+
+            # Configure aria2 for Scoop
+            if (Get-Command scoop -ErrorAction SilentlyContinue) {
+                scoop config aria2-enabled true 2>$null
+                scoop config aria2-warning-enabled false 2>$null
+            }
+        }
+    }
+
+    # ============================================================================
+    # Phase 6: Chocolatey installation and packages
+    # ============================================================================
+    if (-not $SkipChoco) {
+        Write-Host ''
+        Write-Host '[6/7] Setting up Chocolatey...' -ForegroundColor Cyan
+
+        # Install Chocolatey if not present
+        if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+            Write-Status 'Installing Chocolatey...' -Status 'RUNNING'
+            try {
+                Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+                Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile "$env:TEMP\choco-install.ps1"
+                & "$env:TEMP\choco-install.ps1"
+                Remove-Item "$env:TEMP\choco-install.ps1" -Force -ErrorAction SilentlyContinue
+                Write-Status 'Chocolatey installed' -Status 'OK'
+            } catch {
+                Write-Status "Chocolatey installation failed: $_" -Status 'FAIL'
+            }
+        } else {
+            Write-Status 'Chocolatey already installed' -Status 'OK'
+        }
+    }
+
+    # ============================================================================
+    # Phase 7: Windows optional features (if admin)
+    # ============================================================================
+    if (-not $SkipSystemFeatures -and $isAdmin) {
+        Write-Host ''
+        Write-Host '[7/7] Enabling Windows optional features...' -ForegroundColor Cyan
+
+        $features = @(
+            'Microsoft-Windows-Subsystem-Linux',
+            'VirtualMachinePlatform',
+            'LegacyComponents',
+            'DirectPlay'
+        )
+
+        foreach ($feature in $features) {
+            try {
+                DISM /Online /Enable-Feature /FeatureName:$feature /All /NoRestart /Quiet 2>&1 | Out-Null
+                Write-Status "Feature '$feature' enabled" -Status 'OK'
+            } catch {
+                Write-Status "Feature '$feature' (may already be enabled)" -Status 'SKIP'
+            }
+        }
+    }
+
+    # ============================================================================
+    # Phase 8: Post-Install Windows Setup (from autounattend.xml)
+    # ============================================================================
+    if ($ApplyPostInstall -and $isAdmin) {
+        Write-Host ''
+        Write-Host '[8/7] Applying post-install Windows configuration...' -ForegroundColor Cyan
+
+        # Set timezone
+        try {
+            Set-TimeZone -Name $PostInstallTimeZone -ErrorAction Stop
+            Write-Status "Timezone set to '$PostInstallTimeZone'" -Status 'OK'
+        } catch {
+            try {
+                tzutil.exe /s $PostInstallTimeZone 2>&1 | Out-Null
+                Write-Status "Timezone set to '$PostInstallTimeZone' (tzutil)" -Status 'OK'
+            } catch {
+                Write-Status "Timezone '$PostInstallTimeZone' - $($_.Exception.Message)" -Status 'SKIP'
             }
         }
 
-        # Configure aria2 for Scoop
-        if (Get-Command scoop -ErrorAction SilentlyContinue) {
-            scoop config aria2-enabled true 2>$null
-            scoop config aria2-warning-enabled false 2>$null
-        }
-    }
-}
-
-# ============================================================================
-# Phase 6: Chocolatey installation and packages
-# ============================================================================
-if (-not $SkipChoco) {
-    Write-Host ''
-    Write-Host '[6/7] Setting up Chocolatey...' -ForegroundColor Cyan
-
-    # Install Chocolatey if not present
-    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
-        Write-Status 'Installing Chocolatey...' -Status 'RUNNING'
+        # Disable WPBT (Windows Platform Binary Table) - prevents malicious firmware attacks
         try {
-            Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-            Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile "$env:TEMP\choco-install.ps1"
-            & "$env:TEMP\choco-install.ps1"
-            Remove-Item "$env:TEMP\choco-install.ps1" -Force -ErrorAction SilentlyContinue
-            Write-Status 'Chocolatey installed' -Status 'OK'
+            $sysHive = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"
+            if (-not (Test-Path $sysHive)) {
+                New-Item -Path $sysHive -Force | Out-Null
+            }
+            Set-ItemProperty -Path $sysHive -Name 'DisableWpbtExecution' -Value 1 -Type DWord -Force
+            Write-Status 'WPBT execution disabled' -Status 'OK'
         } catch {
-            Write-Status "Chocolatey installation failed: $_" -Status 'FAIL'
+            Write-Status "WPBT disable failed: $($_.Exception.Message)" -Status 'SKIP'
         }
-    } else {
-        Write-Status 'Chocolatey already installed' -Status 'OK'
-    }
-}
 
-# ============================================================================
-# Phase 7: Windows optional features (if admin)
-# ============================================================================
-if (-not $SkipSystemFeatures -and $isAdmin) {
-    Write-Host ''
-    Write-Host '[7/7] Enabling Windows optional features...' -ForegroundColor Cyan
-
-    $features = @(
-        'Microsoft-Windows-Subsystem-Linux',
-        'VirtualMachinePlatform',
-        'LegacyComponents',
-        'DirectPlay'
-    )
-
-    foreach ($feature in $features) {
+        # Set geographic region (GeoId)
         try {
-            DISM /Online /Enable-Feature /FeatureName:$feature /All /NoRestart /Quiet 2>&1 | Out-Null
-            Write-Status "Feature '$feature' enabled" -Status 'OK'
+            $regionKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion"
+            if (-not (Test-Path $regionKey)) {
+                New-Item -Path $regionKey -Force | Out-Null
+            }
+            Set-ItemProperty -Path $regionKey -Name 'DeviceRegion' -Value $PostInstallGeoId -Type DWord -Force
+            Write-Status "Geographic region set to GeoId $PostInstallGeoId" -Status 'OK'
         } catch {
-            Write-Status "Feature '$feature' (may already be enabled)" -Status 'SKIP'
+            Write-Status "GeoId set failed: $($_.Exception.Message)" -Status 'SKIP'
         }
-    }
-}
 
-# ============================================================================
-# Phase 8: Post-Install Windows Setup (from autounattend.xml)
-# ============================================================================
-if ($ApplyPostInstall -and $isAdmin) {
-    Write-Host ''
-    Write-Host '[8/7] Applying post-install Windows configuration...' -ForegroundColor Cyan
-
-    # Set timezone
-    try {
-        Set-TimeZone -Name $PostInstallTimeZone -ErrorAction Stop
-        Write-Status "Timezone set to '$PostInstallTimeZone'" -Status 'OK'
-    } catch {
+        # BypassSetup LabConfig (for future reinstallation/repair)
+        $labConfig = "HKLM:\SYSTEM\Setup\LabConfig"
         try {
-            tzutil.exe /s $PostInstallTimeZone 2>&1 | Out-Null
-            Write-Status "Timezone set to '$PostInstallTimeZone' (tzutil)" -Status 'OK'
+            if (-not (Test-Path $labConfig)) {
+                New-Item -Path $labConfig -Force | Out-Null
+            }
+            Set-ItemProperty -Path $labConfig -Name 'BypassTPMCheck' -Value 1 -Type DWord -Force
+            Set-ItemProperty -Path $labConfig -Name 'BypassSecureBootCheck' -Value 1 -Type DWord -Force
+            Set-ItemProperty -Path $labConfig -Name 'BypassRAMCheck' -Value 1 -Type DWord -Force
+            Write-Status 'Setup bypass flags configured' -Status 'OK'
         } catch {
-            Write-Status "Timezone '$PostInstallTimeZone' - $($_.Exception.Message)" -Status 'SKIP'
+            Write-Status "LabConfig setup failed: $($_.Exception.Message)" -Status 'SKIP'
         }
-    }
 
-    # Disable WPBT (Windows Platform Binary Table) - prevents malicious firmware attacks
-    try {
-        $sysHive = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"
-        if (-not (Test-Path $sysHive)) {
-            New-Item -Path $sysHive -Force | Out-Null
+        # Set system locale
+        try {
+            Set-Culture -CultureInfo $PostInstallInputLocale -ErrorAction Stop
+            Write-Status "System locale set to '$PostInstallInputLocale'" -Status 'OK'
+        } catch {
+            Write-Status "System locale - $($_.Exception.Message)" -Status 'SKIP'
         }
-        Set-ItemProperty -Path $sysHive -Name 'DisableWpbtExecution' -Value 1 -Type DWord -Force
-        Write-Status 'WPBT execution disabled' -Status 'OK'
-    } catch {
-        Write-Status "WPBT disable failed: $($_.Exception.Message)" -Status 'SKIP'
-    }
 
-    # Set geographic region (GeoId)
-    try {
-        $regionKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion"
-        if (-not (Test-Path $regionKey)) {
-            New-Item -Path $regionKey -Force | Out-Null
+        # Strip 8.3 names (reduces disk usage, improves performance)
+        try {
+            $systemDrive = $env:SystemDrive.TrimEnd('\')
+            fsutil.exe 8dot3name set $systemDrive 1 2>&1 | Out-Null
+            fsutil.exe 8dot3name strip /s /f $systemDrive 2>&1 | Out-Null
+            Write-Status '8.3 file name stripping scheduled' -Status 'OK'
+        } catch {
+            Write-Status "8.3 stripping: $($_.Exception.Message)" -Status 'SKIP'
         }
-        Set-ItemProperty -Path $regionKey -Name 'DeviceRegion' -Value $PostInstallGeoId -Type DWord -Force
-        Write-Status "Geographic region set to GeoId $PostInstallGeoId" -Status 'OK'
-    } catch {
-        Write-Status "GeoId set failed: $($_.Exception.Message)" -Status 'SKIP'
+
+        Write-Host ''
+        Write-Host 'Post-install setup completed.' -ForegroundColor Green
     }
 
-    # BypassSetup LabConfig (for future reinstallation/repair)
-    $labConfig = "HKLM:\SYSTEM\Setup\LabConfig"
-    try {
-        if (-not (Test-Path $labConfig)) {
-            New-Item -Path $labConfig -Force | Out-Null
-        }
-        Set-ItemProperty -Path $labConfig -Name 'BypassTPMCheck' -Value 1 -Type DWord -Force
-        Set-ItemProperty -Path $labConfig -Name 'BypassSecureBootCheck' -Value 1 -Type DWord -Force
-        Set-ItemProperty -Path $labConfig -Name 'BypassRAMCheck' -Value 1 -Type DWord -Force
-        Write-Status 'Setup bypass flags configured' -Status 'OK'
-    } catch {
-        Write-Status "LabConfig setup failed: $($_.Exception.Message)" -Status 'SKIP'
-    }
-
-    # Set system locale
-    try {
-        Set-Culture -CultureInfo $PostInstallInputLocale -ErrorAction Stop
-        Write-Status "System locale set to '$PostInstallInputLocale'" -Status 'OK'
-    } catch {
-        Write-Status "System locale - $($_.Exception.Message)" -Status 'SKIP'
-    }
-
-    # Strip 8.3 names (reduces disk usage, improves performance)
-    try {
-        $systemDrive = $env:SystemDrive.TrimEnd('\')
-        fsutil.exe 8dot3name set $systemDrive 1 2>&1 | Out-Null
-        fsutil.exe 8dot3name strip /s /f $systemDrive 2>&1 | Out-Null
-        Write-Status '8.3 file name stripping scheduled' -Status 'OK'
-    } catch {
-        Write-Status "8.3 stripping: $($_.Exception.Message)" -Status 'SKIP'
-    }
-
+    # ============================================================================
+    # Summary
+    # ============================================================================
     Write-Host ''
-    Write-Host 'Post-install setup completed.' -ForegroundColor Green
+    Write-Host 'Package Installation Summary' -ForegroundColor Cyan
+    Write-Host ''
+
+    foreach ($key in $script:Results.Keys | Sort-Object) {
+        $status = $script:Results[$key]
+        $color = switch ($status) { 'OK' { 'Green' } 'FAIL' { 'Red' } 'SKIP' { 'Yellow' } 'RUNNING' { 'Cyan' } default { 'White' } }
+        Write-Host "  $($key.PadRight(50)) : " -NoNewline; Write-Host "$status" -ForegroundColor $color
+    }
+
+    $duration = (Get-Date) - $script:StartTime
+    Write-Host ""
+    Write-Host "  Total time: $($duration.ToString('hh\:mm\:ss'))" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Next: Run Deploy-Config.ps1 to deploy configuration files." -ForegroundColor Yellow
+    Write-Host ""
 }
 
-# ============================================================================
-# Summary
-# ============================================================================
-Write-Host ''
-Write-Host 'Package Installation Summary' -ForegroundColor Cyan
-Write-Host ''
-
-foreach ($key in $script:Results.Keys | Sort-Object) {
-    $status = $script:Results[$key]
-    $color = switch ($status) { 'OK' { 'Green' } 'FAIL' { 'Red' } 'SKIP' { 'Yellow' } 'RUNNING' { 'Cyan' } default { 'White' } }
-    Write-Host "  $($key.PadRight(50)) : " -NoNewline; Write-Host "$status" -ForegroundColor $color
+if ($MyInvocation.InvocationName -ne '.') {
+    Start-InstallPackages @PSBoundParameters
+    $exitCode = $LASTEXITCODE
+    if ($null -ne $exitCode) { exit $exitCode }
 }
-
-$duration = (Get-Date) - $script:StartTime
-Write-Host ""
-Write-Host "  Total time: $($duration.ToString('hh\:mm\:ss'))" -ForegroundColor Cyan
-Write-Host ""
-Write-Host "  Next: Run Deploy-Config.ps1 to deploy configuration files." -ForegroundColor Yellow
-Write-Host ""

--- a/Scripts/Install-Packages.ps1
+++ b/Scripts/Install-Packages.ps1
@@ -85,7 +85,8 @@ function Start-InstallPackages {
         if ($PSCmdlet.ShouldProcess($Name, 'Install via winget')) {
             Write-Host "  Installing $Name..." -ForegroundColor Gray -NoNewline
             try {
-                winget install --id $Id --silent --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+                winget install --id $Id --silent --accept-source-agreements `
+                --accept-package-agreements 2>&1 | Out-Null
                 $ec = $LASTEXITCODE
                 if ($ec -eq 0 -or $ec -eq -1978335189) {
                     Write-Host " [OK]" -ForegroundColor Green

--- a/Scripts/Install-Packages.ps1
+++ b/Scripts/Install-Packages.ps1
@@ -110,7 +110,8 @@ function Start-InstallPackages {
     if ($null -eq $script:isAdminOverride) {
         $isAdmin = $false
         try {
-            $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+            $isAdmin = ([Security.Principal.WindowsPrincipal]`
+                [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
                 [Security.Principal.WindowsBuiltInRole]::Administrator
             )
         } catch {}
@@ -236,7 +237,8 @@ function Start-InstallPackages {
             Write-Status 'Installing Scoop...' -Status 'RUNNING'
             try {
                 $scoopInstaller = Join-Path $env:TEMP ("install-scoop-{0}.ps1" -f [System.Guid]::NewGuid().ToString('N'))
-                Invoke-RestMethod -Uri 'https://get.scoop.sh' -OutFile $scoopInstaller
+                Invoke-RestMethod -Uri 'https://get.scoop.sh' `
+                -OutFile $scoopInstaller
                 & $scoopInstaller
                 Remove-Item $scoopInstaller -Force -ErrorAction SilentlyContinue
                 Write-Status 'Scoop installed' -Status 'OK'
@@ -279,7 +281,8 @@ function Start-InstallPackages {
             Write-Status 'Installing Chocolatey...' -Status 'RUNNING'
             try {
                 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-                Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' -OutFile "$env:TEMP\choco-install.ps1"
+                Invoke-RestMethod -Uri 'https://community.chocolatey.org/install.ps1' `
+                -OutFile "$env:TEMP\choco-install.ps1"
                 & "$env:TEMP\choco-install.ps1"
                 Remove-Item "$env:TEMP\choco-install.ps1" -Force -ErrorAction SilentlyContinue
                 Write-Status 'Chocolatey installed' -Status 'OK'
@@ -366,7 +369,8 @@ function Start-InstallPackages {
                 New-Item -Path $labConfig -Force | Out-Null
             }
             Set-ItemProperty -Path $labConfig -Name 'BypassTPMCheck' -Value 1 -Type DWord -Force
-            Set-ItemProperty -Path $labConfig -Name 'BypassSecureBootCheck' -Value 1 -Type DWord -Force
+            Set-ItemProperty -Path $labConfig -Name 'BypassSecureBootCheck' `
+                -Value 1 -Type DWord -Force
             Set-ItemProperty -Path $labConfig -Name 'BypassRAMCheck' -Value 1 -Type DWord -Force
             Write-Status 'Setup bypass flags configured' -Status 'OK'
         } catch {


### PR DESCRIPTION
🧪 Add test file for Install-Packages.ps1

🎯 **What:** Missing test file for Install-Packages.ps1. Refactored the script slightly to encapsulate logic in a `Start-InstallPackages` function so it can be tested safely. Added safeguards for platform-specific API calls (`[Security.Principal.WindowsPrincipal]`).
📊 **Coverage:** Tests script initialization (dot-sourcing execution guard), and ensures that all parameters like `-SkipWinget`, `-SkipScoop`, `-SkipChoco`, and `-SkipSystemFeatures` correctly bypass the respective phases by asserting the correct mocks are ignored.
✨ **Result:** Solid unit test coverage allowing confident refactoring of the installation steps without unexpected side-effects.

---
*PR created automatically by Jules for task [3910721265979557753](https://jules.google.com/task/3910721265979557753) started by @Ven0m0*