### PR TITLE
🧪 Add test file for fix-system.ps1

### DIFF
--- a/Scripts/fix-system.Tests.ps1
+++ b/Scripts/fix-system.Tests.ps1
@@ -1,0 +1,81 @@
+BeforeAll {
+    Import-Module Pester -MinimumVersion 5.0
+}
+
+Describe "fix-system.ps1" {
+    BeforeAll {
+        function DISM { }
+        function cmd { }
+        function chkdsk { }
+        function winmgmt { }
+        function USOClient.exe { }
+
+        . "$PSScriptRoot/fix-system.ps1"
+    }
+
+    BeforeEach {
+        Mock -CommandName 'DISM' -MockWith { return }
+        Mock -CommandName 'cmd' -MockWith { return }
+        Mock -CommandName 'chkdsk' -MockWith { return }
+        Mock -CommandName 'winmgmt' -MockWith { return }
+        Mock -CommandName 'USOClient.exe' -MockWith { return }
+
+        Mock -CommandName 'Write-Header' -MockWith { return }
+        Mock -CommandName 'Write-Info' -MockWith { return }
+        Mock -CommandName 'Write-Warn' -MockWith { return }
+        Mock -CommandName 'Write-Success' -MockWith { return }
+        Mock -CommandName 'Write-Error' -MockWith { return }
+        Mock -CommandName 'Add-Log' -MockWith { return }
+        Mock -CommandName 'Clear-Log' -MockWith { return }
+        Mock -CommandName 'Get-Log' -MockWith { return @("Mock Log") }
+        Mock -CommandName 'Measure-Execution' -MockWith { return [pscustomobject]@{ EndTime = (Get-Date); Duration = "00:00:01" } }
+        Mock -CommandName 'Show-Summary' -MockWith { return }
+
+        # Override Common.ps1's Invoke-Operation inside Pester
+        # Looking at Common.ps1 it defines `param([Parameter(Mandatory)] [scriptblock]$Action, ...)`
+        # If we just mock it and don't care about the params, Pester still validates the mandatory parameter signature of the original function.
+        # We can bypass this by redefining the function entirely before we Mock it, OR passing a Mock parameter filter, or mocking the Command/Action appropriately.
+        # Let's redefine Invoke-Operation to not require Action.
+    }
+
+    Context "Execution Modes" {
+        BeforeAll {
+            function Invoke-Operation {
+                param(
+                    [string]$Name,
+                    [hashtable]$Results,
+                    [string]$Command,
+                    [string]$ArgumentList,
+                    [scriptblock]$Action = { }
+                )
+            }
+        }
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-Operation' -MockWith { return }
+            Mock -CommandName 'Invoke-ServiceOperation' -MockWith { param($Name, $Action) & $Action }
+            Mock -CommandName 'Write-Host' -MockWith { return }
+            Mock -CommandName 'Rename-Item' -MockWith { return }
+            Mock -CommandName 'Test-Path' -MockWith { return $true }
+            Mock -CommandName 'Set-Content' -MockWith { return }
+        }
+
+        It "Should run in DryRun mode without errors" {
+            { Start-SystemFix -DryRun -NoReboot -NoReport } | Should -Not -Throw
+        }
+
+        It "Should run QuickScan without errors" {
+            { Start-SystemFix -QuickScan -NoReboot -NoReport } | Should -Not -Throw
+            Assert-MockCalled 'chkdsk' -Times 0 -Exactly
+            Assert-MockCalled 'winmgmt' -Times 0 -Exactly
+        }
+
+        It "Should run standard execution without errors" {
+            { Start-SystemFix -NoReboot -NoReport } | Should -Not -Throw
+            Assert-MockCalled 'DISM'
+            Assert-MockCalled 'cmd'
+            Assert-MockCalled 'chkdsk'
+            Assert-MockCalled 'winmgmt'
+        }
+    }
+}

--- a/Scripts/fix-system.ps1
+++ b/Scripts/fix-system.ps1
@@ -34,371 +34,379 @@
     Date: 2026-04-10
 #>
 
-[CmdletBinding()]
-param(
-    [switch]$QuickScan,
-    [switch]$SkipDiskCheck,
-    [switch]$SkipNetworkFix,
-    [switch]$SkipWUReset,
-    [switch]$ScheduleChkdsk,
-    [switch]$DryRun,
-    [switch]$NoReboot,
-    [switch]$NoReport
-)
-
-$ErrorActionPreference = 'Continue'
-$ProgressPreference = 'SilentlyContinue'
-
 # Import common functions
 . "$PSScriptRoot\Common.ps1"
 
-# Initialize logging
-Clear-Log
-$Results = @{
-    DISM = 'SKIPPED'
-    SFC1 = 'SKIPPED'
-    CHKDSK = 'SKIPPED'
-    Network = 'SKIPPED'
-    WMI = 'SKIPPED'
-    WUReset = 'SKIPPED'
-    Cleanup = 'SKIPPED'
-    SFC2 = 'SKIPPED'
-}
+function Start-SystemFix {
 
-$StartTime = Get-Date
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [switch]$QuickScan,
+        [switch]$SkipDiskCheck,
+        [switch]$SkipNetworkFix,
+        [switch]$SkipWUReset,
+        [switch]$ScheduleChkdsk,
+        [switch]$DryRun,
+        [switch]$NoReboot,
+        [switch]$NoReport
+    )
 
-Write-Header "Windows System Repair"
-Write-Info "Start Time: $($StartTime.ToString('yyyy-MM-dd HH:mm:ss'))"
-Write-Info "Parameters: QuickScan=$QuickScan, SkipDiskCheck=$SkipDiskCheck, SkipNetworkFix=$SkipNetworkFix, SkipWUReset=$SkipWUReset, ScheduleChkdsk=$ScheduleChkdsk, DryRun=$DryRun, NoReboot=$NoReboot"
+    $ErrorActionPreference = 'Continue'
+    $ProgressPreference = 'SilentlyContinue'
 
-if ($DryRun) {
-    Write-Warn "DRY RUN MODE - No commands will be executed"
-}
-
-Add-Log "Repair started with parameters: QuickScan=$QuickScan, SkipDiskCheck=$SkipDiskCheck, SkipNetworkFix=$SkipNetworkFix, SkipWUReset=$SkipWUReset, ScheduleChkdsk=$ScheduleChkdsk, DryRun=$DryRun, NoReboot=$NoReboot"
-
-# Step 1: DISM Health Check
-Write-Info "=== Step 1: DISM Health Check ==="
-
-if ($DryRun) {
-    $Results.DISM = 'DRY RUN'
-    Write-Warn "[DRY RUN] Would run DISM commands"
-}
-else {
-    Write-Info "DISM /Online /Cleanup-Image /CheckHealth"
-    $result = & DISM /Online /Cleanup-Image /CheckHealth 2>&1
-    $exitCode = $LASTEXITCODE
-    Add-Log "CheckHealth output: $result"
-    Write-Info "Exit code: $exitCode"
-
-    if ($exitCode -eq 0 -or $exitCode -eq 3010) {
-        Write-Success "DISM CheckHealth: No corruption found or already scheduled"
-        $Results.DISM = 'HEALTHY'
+    # Initialize logging
+    Clear-Log
+    $Results = @{
+        DISM = 'SKIPPED'
+        SFC1 = 'SKIPPED'
+        CHKDSK = 'SKIPPED'
+        Network = 'SKIPPED'
+        WMI = 'SKIPPED'
+        WUReset = 'SKIPPED'
+        Cleanup = 'SKIPPED'
+        SFC2 = 'SKIPPED'
     }
-    elseif ($exitCode -eq 2) {
-        Write-Warn "DISM CheckHealth: Corruption detected, running ScanHealth..."
-        Write-Info "DISM /Online /Cleanup-Image /ScanHealth"
-        & DISM /Online /Cleanup-Image /ScanHealth 2>&1 | Add-Log
-        $scanExitCode = $LASTEXITCODE
 
-        Write-Info "DISM /Online /Cleanup-Image /RestoreHealth"
-        $result = & DISM /Online /Cleanup-Image /RestoreHealth 2>&1
-        $restoreExitCode = $LASTEXITCODE
-        Add-Log "RestoreHealth output: $result"
+    $StartTime = Get-Date
 
-        if ($restoreExitCode -eq 0 -or $restoreExitCode -eq 3010) {
-            Write-Success "DISM RestoreHealth completed"
-            $Results.DISM = 'REPAIRED'
-        }
-        elseif ($restoreExitCode -eq 1392) {
-            Write-Warn "DISM RestoreHealth failed: File corruption, trying /LimitAccess..."
-            $result = & DISM /Online /Cleanup-Image /RestoreHealth /LimitAccess 2>&1
-            Add-Log "RestoreHealth /LimitAccess: $result"
-            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
-                $Results.DISM = 'REPAIRED (LimitAccess)'
-            }
-            else {
-                $Results.DISM = "PARTIAL (Exit: $restoreExitCode)"
-            }
-        }
-        else {
-            Write-Warn "DISM RestoreHealth exit code: $restoreExitCode"
-            $Results.DISM = "Exit Code: $restoreExitCode"
-        }
+    Write-Header "Windows System Repair"
+    Write-Info "Start Time: $($StartTime.ToString('yyyy-MM-dd HH:mm:ss'))"
+    Write-Info "Parameters: QuickScan=$QuickScan, SkipDiskCheck=$SkipDiskCheck, SkipNetworkFix=$SkipNetworkFix, SkipWUReset=$SkipWUReset, ScheduleChkdsk=$ScheduleChkdsk, DryRun=$DryRun, NoReboot=$NoReboot"
+
+    if ($DryRun) {
+        Write-Warn "DRY RUN MODE - No commands will be executed"
+    }
+
+    Add-Log "Repair started with parameters: QuickScan=$QuickScan, SkipDiskCheck=$SkipDiskCheck, SkipNetworkFix=$SkipNetworkFix, SkipWUReset=$SkipWUReset, ScheduleChkdsk=$ScheduleChkdsk, DryRun=$DryRun, NoReboot=$NoReboot"
+
+    # Step 1: DISM Health Check
+    Write-Info "=== Step 1: DISM Health Check ==="
+
+    if ($DryRun) {
+        $Results.DISM = 'DRY RUN'
+        Write-Warn "[DRY RUN] Would run DISM commands"
     }
     else {
-        Write-Warn "DISM CheckHealth exit code: $exitCode"
-        $Results.DISM = "Exit Code: $exitCode"
-    }
-}
+        Write-Info "DISM /Online /Cleanup-Image /CheckHealth"
+        $result = & DISM /Online /Cleanup-Image /CheckHealth 2>&1
+        $exitCode = $LASTEXITCODE
+        Add-Log "CheckHealth output: $result"
+        Write-Info "Exit code: $exitCode"
 
-# Step 2: SFC System File Check (Pass 1)
-Write-Info "=== Step 2: SFC System File Check (Pass 1) ==="
-
-if ($DryRun) {
-    $Results.SFC1 = 'DRY RUN'
-    Write-Warn "[DRY RUN] Would run: sfc /scannow"
-}
-else {
-    Write-Info "Running SFC /scannow (this may take 10-30 minutes)..."
-    Write-Info "SFC output goes to stderr - capturing properly..."
-
-    $sfcOutput = & cmd /c "sfc /scannow 2>&1"
-    $sfcExitCode = $LASTEXITCODE
-
-    Add-Log "SFC Output: $sfcOutput"
-
-    if ($sfcExitCode -eq 0) {
-        Write-Success "SFC found no integrity violations"
-        $Results.SFC1 = 'CLEAN'
-    }
-    elseif ($sfcExitCode -eq 1) {
-        Write-Success "SFC found and repaired integrity violations"
-        $Results.SFC1 = 'REPAIRED'
-    }
-    elseif ($sfcExitCode -eq 2) {
-        Write-Warn "SFC found integrity violations but could not repair them all"
-        $Results.SFC1 = 'PARTIAL'
-    }
-    else {
-        Write-Warn "SFC exit code: $sfcExitCode"
-        $Results.SFC1 = "Exit Code: $sfcExitCode"
-    }
-}
-
-if (-not $QuickScan) {
-    if (-not $SkipDiskCheck) {
-        # Step 3: CHKDSK Disk Repair
-        Write-Info "=== Step 3: CHKDSK Disk Repair ==="
-
-        if ($DryRun) {
-            $Results.CHKDSK = 'DRY RUN'
-            Write-Warn "[DRY RUN] Would run: chkdsk C: /scan"
+        if ($exitCode -eq 0 -or $exitCode -eq 3010) {
+            Write-Success "DISM CheckHealth: No corruption found or already scheduled"
+            $Results.DISM = 'HEALTHY'
         }
-        else {
-            Write-Info "Running CHKDSK /scan (online, non-disruptive)..."
-            $chkdskOutput = & chkdsk C: /scan 2>&1
-            $chkdskExitCode = $LASTEXITCODE
+        elseif ($exitCode -eq 2) {
+            Write-Warn "DISM CheckHealth: Corruption detected, running ScanHealth..."
+            Write-Info "DISM /Online /Cleanup-Image /ScanHealth"
+            & DISM /Online /Cleanup-Image /ScanHealth 2>&1 | Add-Log
+            $scanExitCode = $LASTEXITCODE
 
-            Add-Log "CHKDSK /scan: $chkdskOutput"
+            Write-Info "DISM /Online /Cleanup-Image /RestoreHealth"
+            $result = & DISM /Online /Cleanup-Image /RestoreHealth 2>&1
+            $restoreExitCode = $LASTEXITCODE
+            Add-Log "RestoreHealth output: $result"
 
-            if ($chkdskExitCode -eq 0) {
-                Write-Success "CHKDSK: No errors found"
-                $Results.CHKDSK = 'CLEAN'
+            if ($restoreExitCode -eq 0 -or $restoreExitCode -eq 3010) {
+                Write-Success "DISM RestoreHealth completed"
+                $Results.DISM = 'REPAIRED'
             }
-            elseif ($chkdskExitCode -eq 1) {
-                Write-Success "CHKDSK: Errors found and fixed"
-                $Results.CHKDSK = 'FIXED'
-            }
-            elseif ($chkdskExitCode -eq 2) {
-                Write-Warn "CHKDSK: Scheduled for next reboot (requires /f)"
-                $Results.CHKDSK = 'SCHEDULED'
-
-                if ($ScheduleChkdsk) {
-                    Write-Info "Scheduling CHKDSK /f /r for next reboot..."
-                    & chkdsk C: /f /r 2>&1 | Out-Null
-                    Write-Warn "CHKDSK /f /r scheduled for next reboot"
-                    $Results.CHKDSK = 'SCHEDULED (reboot)'
+            elseif ($restoreExitCode -eq 1392) {
+                Write-Warn "DISM RestoreHealth failed: File corruption, trying /LimitAccess..."
+                $result = & DISM /Online /Cleanup-Image /RestoreHealth /LimitAccess 2>&1
+                Add-Log "RestoreHealth /LimitAccess: $result"
+                if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
+                    $Results.DISM = 'REPAIRED (LimitAccess)'
+                }
+                else {
+                    $Results.DISM = "PARTIAL (Exit: $restoreExitCode)"
                 }
             }
             else {
-                Write-Warn "CHKDSK exit code: $chkdskExitCode"
-                $Results.CHKDSK = "Exit Code: $chkdskExitCode"
+                Write-Warn "DISM RestoreHealth exit code: $restoreExitCode"
+                $Results.DISM = "Exit Code: $restoreExitCode"
             }
         }
-    }
-    else {
-        Write-Info "Skipping CHKDSK (SkipDiskCheck parameter)"
-    }
-
-    if (-not $SkipNetworkFix) {
-        # Step 4: Network Repairs
-        Write-Info "=== Step 4: Network Repairs ==="
-
-        if ($DryRun) {
-            $Results.Network = 'DRY RUN'
-            Write-Warn "[DRY RUN] Would run: netsh winsock reset, netsh int ip reset, ipconfig /flushdns"
-        }
         else {
-            Invoke-Operation -Name 'WinsockReset' -Results $Results -Command 'netsh' -ArgumentList 'winsock reset'
-            Invoke-Operation -Name 'TCPIPReset' -Results $Results -Command 'netsh' -ArgumentList 'int ip reset'
-            Invoke-Operation -Name 'DNSFlush' -Results $Results -Command 'ipconfig' -ArgumentList '/flushdns'
-
-            Write-Success "Network repairs complete"
-            $Results.Network = 'COMPLETE'
-            Write-Warn "NOTE: A reboot is required for network changes to take effect"
+            Write-Warn "DISM CheckHealth exit code: $exitCode"
+            $Results.DISM = "Exit Code: $exitCode"
         }
     }
-    else {
-        Write-Info "Skipping Network repairs (SkipNetworkFix parameter)"
-    }
 
-    # Step 5: WMI Repository Check
-    Write-Info "=== Step 5: WMI Repository Check ==="
+    # Step 2: SFC System File Check (Pass 1)
+    Write-Info "=== Step 2: SFC System File Check (Pass 1) ==="
 
     if ($DryRun) {
-        $Results.WMI = 'DRY RUN'
-        Write-Warn "[DRY RUN] Would run: winmgmt /verifyrepository"
-    }
-    else {
-        Write-Info "Verifying WMI repository..."
-        $wmiOutput = & winmgmt /verifyrepository 2>&1
-        $wmiExitCode = $LASTEXITCODE
-
-        Add-Log "WMI Verify: $wmiOutput"
-
-        if ($wmiOutput -match 'consistent|ok|OK') {
-            Write-Success "WMI repository is consistent"
-            $Results.WMI = 'CONSISTENT'
-        }
-        elseif ($wmiOutput -match 'inconsistent|ERROR') {
-            Write-Warn "WMI repository is inconsistent, attempting repair..."
-            $salvageOutput = & winmgmt /salvagerepository 2>&1
-            $salvageExitCode = $LASTEXITCODE
-
-            Add-Log "WMI Salvage: $salvageOutput"
-
-            if ($salvageExitCode -eq 0) {
-                Write-Success "WMI repository repaired"
-                $Results.WMI = 'REPAIRED'
-            }
-            else {
-                Write-Warn "WMI salvage exit code: $salvageExitCode"
-                $Results.WMI = "Exit Code: $salvageExitCode"
-            }
-        }
-        else {
-            Write-Warn "WMI verify exit code: $wmiExitCode"
-            $Results.WMI = "Exit Code: $wmiExitCode"
-        }
-    }
-
-    if (-not $SkipWUReset) {
-        # Step 6: Windows Update Service Reset
-        Write-Info "=== Step 6: Windows Update Service Reset ==="
-
-        if ($DryRun) {
-            $Results.WUReset = 'DRY RUN'
-            Write-Warn "[DRY RUN] Would reset Windows Update services"
-        }
-        else {
-            Invoke-ServiceOperation -Name 'wuauserv' -Action {
-                Invoke-ServiceOperation -Name 'BITS' -Action {
-                    $swDistribPath = "$env:SystemRoot\SoftwareDistribution"
-                    $catRootPath = "$env:SystemRoot\System32\CatRoot2"
-
-                    if (Test-Path $swDistribPath) {
-                        $backupName = "$swDistribPath-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
-                        Write-Info "Renaming SoftwareDistribution to $backupName"
-                        Rename-Item -Path $swDistribPath -NewName (Split-Path -Leaf $backupName) -Force -ErrorAction SilentlyContinue
-                    }
-
-                    if (Test-Path $catRootPath) {
-                        $backupName = "$catRootPath-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
-                        Write-Info "Renaming CatRoot2 to $backupName"
-                        Rename-Item -Path $catRootPath -NewName (Split-Path -Leaf $backupName) -Force -ErrorAction SilentlyContinue
-                    }
-
-                    Write-Info "Triggering Windows Update scan..."
-                    & USOClient.exe ScanDownloadBranch 2>&1 | Out-Null
-
-                    $Results.WUReset = 'COMPLETE'
-                    Write-Success "Windows Update service reset complete"
-                }
-            }
-        }
-    }
-    else {
-        Write-Info "Skipping Windows Update reset (SkipWUReset parameter)"
-    }
-
-    # Step 7: SFC System File Check (Pass 2 - after network fixes)
-    Write-Info "=== Step 7: SFC System File Check (Pass 2 - after network fixes) ==="
-
-    if ($DryRun) {
-        $Results.SFC2 = 'DRY RUN'
+        $Results.SFC1 = 'DRY RUN'
         Write-Warn "[DRY RUN] Would run: sfc /scannow"
     }
     else {
-        Write-Info "Running SFC /scannow (second pass)..."
+        Write-Info "Running SFC /scannow (this may take 10-30 minutes)..."
+        Write-Info "SFC output goes to stderr - capturing properly..."
 
         $sfcOutput = & cmd /c "sfc /scannow 2>&1"
         $sfcExitCode = $LASTEXITCODE
 
-        Add-Log "SFC Pass 2: $sfcOutput"
+        Add-Log "SFC Output: $sfcOutput"
 
         if ($sfcExitCode -eq 0) {
-            Write-Success "SFC Pass 2: No integrity violations"
-            $Results.SFC2 = 'CLEAN'
+            Write-Success "SFC found no integrity violations"
+            $Results.SFC1 = 'CLEAN'
         }
         elseif ($sfcExitCode -eq 1) {
-            Write-Success "SFC Pass 2: Repaired additional files"
-            $Results.SFC2 = 'REPAIRED'
+            Write-Success "SFC found and repaired integrity violations"
+            $Results.SFC1 = 'REPAIRED'
+        }
+        elseif ($sfcExitCode -eq 2) {
+            Write-Warn "SFC found integrity violations but could not repair them all"
+            $Results.SFC1 = 'PARTIAL'
         }
         else {
-            Write-Warn "SFC Pass 2 exit code: $sfcExitCode"
-            $Results.SFC2 = "Exit Code: $sfcExitCode"
+            Write-Warn "SFC exit code: $sfcExitCode"
+            $Results.SFC1 = "Exit Code: $sfcExitCode"
         }
     }
 
-    # Step 8: Component Store Cleanup
-    Write-Info "=== Step 8: Component Store Cleanup ==="
+    if (-not $QuickScan) {
+        if (-not $SkipDiskCheck) {
+            # Step 3: CHKDSK Disk Repair
+            Write-Info "=== Step 3: CHKDSK Disk Repair ==="
 
-    if ($DryRun) {
-        $Results.Cleanup = 'DRY RUN'
-        Write-Warn "[DRY RUN] Would run: DISM /Online /Cleanup-Image /StartComponentCleanup"
-    }
-    else {
-        Write-Info "Running DISM StartComponentCleanup (may take 15-30 minutes)..."
+            if ($DryRun) {
+                $Results.CHKDSK = 'DRY RUN'
+                Write-Warn "[DRY RUN] Would run: chkdsk C: /scan"
+            }
+            else {
+                Write-Info "Running CHKDSK /scan (online, non-disruptive)..."
+                $chkdskOutput = & chkdsk C: /scan 2>&1
+                $chkdskExitCode = $LASTEXITCODE
 
-        $cleanupResult = & DISM /Online /Cleanup-Image /StartComponentCleanup 2>&1
-        $cleanupExitCode = $LASTEXITCODE
+                Add-Log "CHKDSK /scan: $chkdskOutput"
 
-        if ($cleanupExitCode -eq 0 -or $cleanupExitCode -eq 3010) {
-            Write-Success "Component cleanup complete"
-            $Results.Cleanup = 'COMPLETED'
+                if ($chkdskExitCode -eq 0) {
+                    Write-Success "CHKDSK: No errors found"
+                    $Results.CHKDSK = 'CLEAN'
+                }
+                elseif ($chkdskExitCode -eq 1) {
+                    Write-Success "CHKDSK: Errors found and fixed"
+                    $Results.CHKDSK = 'FIXED'
+                }
+                elseif ($chkdskExitCode -eq 2) {
+                    Write-Warn "CHKDSK: Scheduled for next reboot (requires /f)"
+                    $Results.CHKDSK = 'SCHEDULED'
+
+                    if ($ScheduleChkdsk) {
+                        Write-Info "Scheduling CHKDSK /f /r for next reboot..."
+                        & chkdsk C: /f /r 2>&1 | Out-Null
+                        Write-Warn "CHKDSK /f /r scheduled for next reboot"
+                        $Results.CHKDSK = 'SCHEDULED (reboot)'
+                    }
+                }
+                else {
+                    Write-Warn "CHKDSK exit code: $chkdskExitCode"
+                    $Results.CHKDSK = "Exit Code: $chkdskExitCode"
+                }
+            }
         }
         else {
-            Write-Warn "Cleanup exit code: $cleanupExitCode"
-            $Results.Cleanup = "Exit Code: $cleanupExitCode"
+            Write-Info "Skipping CHKDSK (SkipDiskCheck parameter)"
+        }
+
+        if (-not $SkipNetworkFix) {
+            # Step 4: Network Repairs
+            Write-Info "=== Step 4: Network Repairs ==="
+
+            if ($DryRun) {
+                $Results.Network = 'DRY RUN'
+                Write-Warn "[DRY RUN] Would run: netsh winsock reset, netsh int ip reset, ipconfig /flushdns"
+            }
+            else {
+                Invoke-Operation -Name 'WinsockReset' -Results $Results -Command 'netsh' -ArgumentList 'winsock reset'
+                Invoke-Operation -Name 'TCPIPReset' -Results $Results -Command 'netsh' -ArgumentList 'int ip reset'
+                Invoke-Operation -Name 'DNSFlush' -Results $Results -Command 'ipconfig' -ArgumentList '/flushdns'
+
+                Write-Success "Network repairs complete"
+                $Results.Network = 'COMPLETE'
+                Write-Warn "NOTE: A reboot is required for network changes to take effect"
+            }
+        }
+        else {
+            Write-Info "Skipping Network repairs (SkipNetworkFix parameter)"
+        }
+
+        # Step 5: WMI Repository Check
+        Write-Info "=== Step 5: WMI Repository Check ==="
+
+        if ($DryRun) {
+            $Results.WMI = 'DRY RUN'
+            Write-Warn "[DRY RUN] Would run: winmgmt /verifyrepository"
+        }
+        else {
+            Write-Info "Verifying WMI repository..."
+            $wmiOutput = & winmgmt /verifyrepository 2>&1
+            $wmiExitCode = $LASTEXITCODE
+
+            Add-Log "WMI Verify: $wmiOutput"
+
+            if ($wmiOutput -match 'consistent|ok|OK') {
+                Write-Success "WMI repository is consistent"
+                $Results.WMI = 'CONSISTENT'
+            }
+            elseif ($wmiOutput -match 'inconsistent|ERROR') {
+                Write-Warn "WMI repository is inconsistent, attempting repair..."
+                $salvageOutput = & winmgmt /salvagerepository 2>&1
+                $salvageExitCode = $LASTEXITCODE
+
+                Add-Log "WMI Salvage: $salvageOutput"
+
+                if ($salvageExitCode -eq 0) {
+                    Write-Success "WMI repository repaired"
+                    $Results.WMI = 'REPAIRED'
+                }
+                else {
+                    Write-Warn "WMI salvage exit code: $salvageExitCode"
+                    $Results.WMI = "Exit Code: $salvageExitCode"
+                }
+            }
+            else {
+                Write-Warn "WMI verify exit code: $wmiExitCode"
+                $Results.WMI = "Exit Code: $wmiExitCode"
+            }
+        }
+
+        if (-not $SkipWUReset) {
+            # Step 6: Windows Update Service Reset
+            Write-Info "=== Step 6: Windows Update Service Reset ==="
+
+            if ($DryRun) {
+                $Results.WUReset = 'DRY RUN'
+                Write-Warn "[DRY RUN] Would reset Windows Update services"
+            }
+            else {
+                Invoke-ServiceOperation -Name 'wuauserv' -Action {
+                    Invoke-ServiceOperation -Name 'BITS' -Action {
+                        $swDistribPath = "$env:SystemRoot\SoftwareDistribution"
+                        $catRootPath = "$env:SystemRoot\System32\CatRoot2"
+
+                        if (Test-Path $swDistribPath) {
+                            $backupName = "$swDistribPath-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+                            Write-Info "Renaming SoftwareDistribution to $backupName"
+                            Rename-Item -Path $swDistribPath -NewName (Split-Path -Leaf $backupName) -Force -ErrorAction SilentlyContinue
+                        }
+
+                        if (Test-Path $catRootPath) {
+                            $backupName = "$catRootPath-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+                            Write-Info "Renaming CatRoot2 to $backupName"
+                            Rename-Item -Path $catRootPath -NewName (Split-Path -Leaf $backupName) -Force -ErrorAction SilentlyContinue
+                        }
+
+                        Write-Info "Triggering Windows Update scan..."
+                        & USOClient.exe ScanDownloadBranch 2>&1 | Out-Null
+
+                        $Results.WUReset = 'COMPLETE'
+                        Write-Success "Windows Update service reset complete"
+                    }
+                }
+            }
+        }
+        else {
+            Write-Info "Skipping Windows Update reset (SkipWUReset parameter)"
+        }
+
+        # Step 7: SFC System File Check (Pass 2 - after network fixes)
+        Write-Info "=== Step 7: SFC System File Check (Pass 2 - after network fixes) ==="
+
+        if ($DryRun) {
+            $Results.SFC2 = 'DRY RUN'
+            Write-Warn "[DRY RUN] Would run: sfc /scannow"
+        }
+        else {
+            Write-Info "Running SFC /scannow (second pass)..."
+
+            $sfcOutput = & cmd /c "sfc /scannow 2>&1"
+            $sfcExitCode = $LASTEXITCODE
+
+            Add-Log "SFC Pass 2: $sfcOutput"
+
+            if ($sfcExitCode -eq 0) {
+                Write-Success "SFC Pass 2: No integrity violations"
+                $Results.SFC2 = 'CLEAN'
+            }
+            elseif ($sfcExitCode -eq 1) {
+                Write-Success "SFC Pass 2: Repaired additional files"
+                $Results.SFC2 = 'REPAIRED'
+            }
+            else {
+                Write-Warn "SFC Pass 2 exit code: $sfcExitCode"
+                $Results.SFC2 = "Exit Code: $sfcExitCode"
+            }
+        }
+
+        # Step 8: Component Store Cleanup
+        Write-Info "=== Step 8: Component Store Cleanup ==="
+
+        if ($DryRun) {
+            $Results.Cleanup = 'DRY RUN'
+            Write-Warn "[DRY RUN] Would run: DISM /Online /Cleanup-Image /StartComponentCleanup"
+        }
+        else {
+            Write-Info "Running DISM StartComponentCleanup (may take 15-30 minutes)..."
+
+            $cleanupResult = & DISM /Online /Cleanup-Image /StartComponentCleanup 2>&1
+            $cleanupExitCode = $LASTEXITCODE
+
+            if ($cleanupExitCode -eq 0 -or $cleanupExitCode -eq 3010) {
+                Write-Success "Component cleanup complete"
+                $Results.Cleanup = 'COMPLETED'
+            }
+            else {
+                Write-Warn "Cleanup exit code: $cleanupExitCode"
+                $Results.Cleanup = "Exit Code: $cleanupExitCode"
+            }
         }
     }
-}
 
-# Display summary
-Show-Summary -Results $Results -StartTime $StartTime
+    # Display summary
+    Show-Summary -Results $Results -StartTime $StartTime
 
-# Write report file
-if (-not $NoReport -and -not $DryRun) {
-    $reportFile = Join-Path $PSScriptRoot "fix-system-report-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
+    # Write report file
+    if (-not $NoReport -and -not $DryRun) {
+        $reportFile = Join-Path $PSScriptRoot "fix-system-report-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
-    $durationInfo = Measure-Execution -StartTime $StartTime
+        $durationInfo = Measure-Execution -StartTime $StartTime
 
-    $report = @"
-Windows System Repair Report
-=====================
-Start Time: $($StartTime.ToString('yyyy-MM-dd HH:mm:ss'))
-End Time: $($durationInfo.EndTime.ToString('yyyy-MM-dd HH:mm:ss'))
-Duration: $($durationInfo.Duration)
-DryRun: $DryRun
-QuickScan: $QuickScan
+        $report = @"
+    Windows System Repair Report
+    =====================
+    Start Time: $($StartTime.ToString('yyyy-MM-dd HH:mm:ss'))
+    End Time: $($durationInfo.EndTime.ToString('yyyy-MM-dd HH:mm:ss'))
+    Duration: $($durationInfo.Duration)
+    DryRun: $DryRun
+    QuickScan: $QuickScan
 
-RESULTS SUMMARY
-==========
-$(($Results.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key) = $($_.Value)" }) -join "`n")
+    RESULTS SUMMARY
+    ==========
+    $(($Results.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key) = $($_.Value)" }) -join "`n")
 
-LOG OUTPUT
-========
-$((Get-Log) -join "`n")
+    LOG OUTPUT
+    ========
+    $((Get-Log) -join "`n")
 "@
 
-    Set-Content -Path $reportFile -Value $report -Encoding UTF8
-    Write-Info "Report written to: $reportFile"
+        Set-Content -Path $reportFile -Value $report -Encoding UTF8
+        Write-Info "Report written to: $reportFile"
+    }
+
+    if (-not $NoReboot -and (-not $DryRun) -and ($Results.Network -eq 'COMPLETE' -or $Results.WUReset -eq 'COMPLETE')) {
+        Write-Host "`nA system REBOOT is recommended to complete network and Windows Update changes." -ForegroundColor Yellow
+        Write-Host "Run: shutdown /r /t 0" -ForegroundColor Yellow
+    }
+
+    Write-Success "Done!"
 }
 
-if (-not $NoReboot -and (-not $DryRun) -and ($Results.Network -eq 'COMPLETE' -or $Results.WUReset -eq 'COMPLETE')) {
-    Write-Host "`nA system REBOOT is recommended to complete network and Windows Update changes." -ForegroundColor Yellow
-    Write-Host "Run: shutdown /r /t 0" -ForegroundColor Yellow
+if ($MyInvocation.InvocationName -ne '.') {
+    Start-SystemFix @PSBoundParameters
+    exit $LASTEXITCODE
 }
-
-Write-Success "Done!"


### PR DESCRIPTION
🎯 **What:** 
Added a test file `Scripts/fix-system.Tests.ps1` to cover `Scripts/fix-system.ps1`. Additionally, refactored `Scripts/fix-system.ps1` to follow the project's standard "testability pattern" by wrapping its execution logic inside a `Start-SystemFix` function with an execution guard, enabling safe dot-sourcing in Pester tests.

📊 **Coverage:** 
- Mocked external commands (e.g., `DISM`, `cmd`, `chkdsk`, `winmgmt`, `USOClient.exe`) and Common script utilities to simulate system calls safely.
- Covered `DryRun` behavior without side effects.
- Covered `QuickScan` behavior, asserting skipping commands appropriately.
- Covered standard execution modes.

✨ **Result:** 
`Scripts/fix-system.ps1` is now testable and successfully passes execution mode validations via Pester.

---
*PR created automatically by Jules for task [15096587257632993834](https://jules.google.com/task/15096587257632993834) started by @Ven0m0*