### PR TITLE
🔒 [security fix] Harden admin function against command injection

### DIFF
--- a/user/.dotfiles/config/powershell/profile.ps1
+++ b/user/.dotfiles/config/powershell/profile.ps1
@@ -329,8 +329,8 @@ function winutil {
 # System Utilities
 function admin {
     if ($args.Count -gt 0) {
-        $argList = $args -join ' '
-        Start-Process wt -Verb runAs -ArgumentList "pwsh.exe -NoExit -Command $argList"
+        $argList = @('pwsh.exe', '-NoExit', '-Command') + $args
+        Start-Process wt -Verb runAs -ArgumentList $argList
     } else {
         Start-Process wt -Verb runAs
     }


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in the `admin` function within the PowerShell profile.

⚠️ **Risk:** User-provided arguments were joined into a single string and passed directly to `Start-Process`, which could allow an attacker to execute arbitrary commands by including shell metacharacters (e.g., `;`, `&`) in the arguments.

🛡️ **Solution:** Switched to passing arguments as an array to the `-ArgumentList` parameter of `Start-Process`. PowerShell's array-based `-ArgumentList` ensures each argument is treated as a literal value, preventing it from being interpreted as multiple commands.

---
*PR created automatically by Jules for task [5292692564477102941](https://jules.google.com/task/5292692564477102941) started by @Ven0m0*