### PR TITLE
🧪 Add tests for Invoke-BuildOperation and fix syntax errors

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 ## Common.ps1 - Shared utility functions for Windows optimization scripts
 # This module provides reusable functions to avoid code duplication
@@ -702,6 +702,7 @@ function Set-MultiPlaneOverlay {
 
 function Show-GamingDisplayStatus {
     [CmdletBinding()]
+    param()
     <#
     .SYNOPSIS
         Displays current gaming display settings
@@ -1158,6 +1159,7 @@ function Add-Log {
 
 function Get-Log {
     [CmdletBinding()]
+    param()
     <#
     .SYNOPSIS
         Returns the accumulated log entries

--- a/tests/Common.Tests.ps1
+++ b/tests/Common.Tests.ps1
@@ -15,7 +15,7 @@ Describe "ConvertFrom-VDF" {
     "name" "Counter-Strike 2"
 }
 "@
-        $lines = $vdf -split "`n"
+        $lines = $vdf -split "`r?`n"
         $result = ConvertFrom-VDF -Content $lines
 
         $result.AppState.appid | Should -Be '"730"'
@@ -36,7 +36,7 @@ Describe "ConvertFrom-VDF" {
     }
 }
 "@
-        $lines = $vdf -split "`n"
+        $lines = $vdf -split "`r?`n"
         $result = ConvertFrom-VDF -Content $lines
 
         $result.AppState.InstalledDepots["731"].manifest | Should -Be '"12345"'
@@ -107,14 +107,14 @@ Describe "VDF Parsing and Converting" {
   }
 }
 "@
-        $lines = $vdf -split "`n"
+        $lines = $vdf -split "`r?`n"
         $parsed = ConvertFrom-VDF -Content $lines
 
         $converted = ConvertTo-VDF -Data $parsed
         $convertedStr = $converted -join ''
         $normalizedConverted = $convertedStr -replace "`r`n", "`n"
 
-        $expected = "`"AppState`"`n{`n`t`"appid`"`t`t`"730`"`n`t`"name`"`t`t`"Counter-Strike 2`"`n`t`"SharedDepots`"`n`t
+        $expected = "`"AppState`"`n{`n`t`"appid`"`t`t`"730`"`n`t`"name`"`t`t`"Counter-Strike 2`"`n`t`"SharedDepots`"`n`t{`n`t`t`"228989`"`t`t`"228980`"`n`t}`n}`n"
 
         $normalizedConverted | Should -Be $expected
     }
@@ -132,8 +132,8 @@ Describe "ConvertFrom-VDF edge cases" {
 
 
         }
-        "@
-        $lines = $vdf -split "`n"
+"@
+        $lines = $vdf -split "`r?`n"
         $result = ConvertFrom-VDF -Content $lines
         $result.AppState.appid | Should -Be '"730"'
     }
@@ -159,8 +159,8 @@ Describe "ConvertFrom-VDF values with spaces" {
             "path" "C:\Program Files (x86)\Steam"
 
         }
-        "@
-        $lines = $vdf -split "`n"
+"@
+        $lines = $vdf -split "`r?`n"
         $result = ConvertFrom-VDF -Content $lines
         $result.AppState.name | Should -Be '"Counter-Strike Global Offensive"'
         $result.AppState.path | Should -Be '"C:\Program Files (x86)\Steam"'
@@ -174,7 +174,7 @@ Describe "Show-RestartRequired" {
 
         Show-RestartRequired
 
-        Should -Invoke Write-Host -Times 1 -ParameterFilter { $Object -eq "Restart required to apply changes..." -and $F
+        Should -Invoke Write-Host -Times 1 -ParameterFilter { $Object -eq "Restart required to apply changes..." -and $ForegroundColor -eq "Yellow" }
         Should -Invoke Wait-ForKeyPress -Times 1
     }
 
@@ -187,5 +187,33 @@ Describe "Show-RestartRequired" {
 
         Should -Invoke Write-Host -Times 1 -ParameterFilter { $Object -eq $msg -and $ForegroundColor -eq "Yellow" }
         Should -Invoke Wait-ForKeyPress -Times 1
+    }
+}
+
+
+Describe "Invoke-BuildOperation" {
+    BeforeEach {
+        Mock Write-Host {}
+    }
+
+    It "Should return `$true and write success status on success" {
+        $result = Invoke-BuildOperation -Name "TestOp" -Action { "Success" }
+        $result | Should -Be $true
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[RUNNING\] TestOp' -and $ForegroundColor -eq 'Cyan' }
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[OK\] TestOp' -and $ForegroundColor -eq 'Green' }
+    }
+
+    It "Should return `$false and write failure status on exception" {
+        $result = Invoke-BuildOperation -Name "FailOp" -Action { throw "Intentional Failure" }
+        $result | Should -Be $false
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[RUNNING\] FailOp' -and $ForegroundColor -eq 'Cyan' }
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[FAIL\] FailOp - Intentional Failure' -and $ForegroundColor -eq 'Red' }
+    }
+
+    It "Should support custom SuccessStatus and colors" {
+        $result = Invoke-BuildOperation -Name "SkipOp" -Action { "Skipped" } -SuccessStatus 'SKIP'
+        $result | Should -Be $true
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[RUNNING\] SkipOp' -and $ForegroundColor -eq 'Cyan' }
+        Should -Invoke -CommandName Write-Host -Times 1 -ParameterFilter { $Object -match '\[SKIP\] SkipOp' -and $ForegroundColor -eq 'Yellow' }
     }
 }


### PR DESCRIPTION
* **What:** The `Invoke-BuildOperation` wrapper function in `Scripts/Common.ps1` was untested. I added Pester tests in `tests/Common.Tests.ps1` to cover its functionality. I also repaired multiple syntax errors that were present in previous VDF test strings, causing discovery failures, and addressed two `param()` missing blocks affecting PS lint warnings.
* **Coverage:** Added coverage for successful execution reporting `[OK]`, exception handling reporting `[FAIL]` and returning false, and support for custom success statuses like `[SKIP]`.
* **Result:** The test suite fully covers `Invoke-BuildOperation` behavior natively validating inputs and terminal outputs, and the entire `Common.Tests.ps1` correctly executes without unhandled string truncation errors.

---
*PR created automatically by Jules for task [12445714803442030557](https://jules.google.com/task/12445714803442030557) started by @Ven0m0*