### PR TITLE
Add LSP configuration files for opencode and kilo editors

### DIFF
--- a/.kilo/kilo.json
+++ b/.kilo/kilo.json
@@ -120,11 +120,11 @@
 			"command": ["bash-language-server", "start"],
 			"extensions": [".sh", ".bash", ".zsh", ".ksh"]
 		},
-		"vtsls": {
+    "vtsls": {
       "command": ["vtsls", "--stdio"],
       "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"],
       "initialization": { "preferences": { "importModuleSpecifierPreference": "relative" } }
-		},
+    },
     "ty": {
       "command": ["ty", "server"],
       "extensions": [".py", ".pyi", ".pyw"]

--- a/.kilo/kilo.json
+++ b/.kilo/kilo.json
@@ -118,16 +118,24 @@
 		},
 		"bash": {
 			"command": ["bash-language-server", "start"],
-			"extensions": [".sh", ".bash", ".zsh"]
+			"extensions": [".sh", ".bash", ".zsh", ".ksh"]
 		},
 		"vtsls": {
       "command": ["vtsls", "--stdio"],
       "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"],
       "initialization": { "preferences": { "importModuleSpecifierPreference": "relative" } }
 		},
+    "ty": {
+      "command": ["ty", "server"],
+      "extensions": [".py", ".pyi", ".pyw"]
+    },
     "rust": {
       "command": ["rust-analyzer"],
       "extensions": [".rs"]
+    },
+    "eslint": {
+      "command": ["vscode-eslint-language-server", "--stdio"],
+      "extensions": [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".vue", ".svelte", ".astro"]
     },
 		"yaml-ls": {
 			"command": ["yaml-language-server", "--stdio"],

--- a/user/.dotfiles/config/kilo/lsp.json
+++ b/user/.dotfiles/config/kilo/lsp.json
@@ -29,7 +29,7 @@
     },
     "css-ls": {
         "command": ["vscode-css-language-server", "--stdio"],
-        "extensions": [".css", ".scss", ".less", ".sass"]
+        "extensions": [".css", ".scss", ".less"]
     },
     "bash": {
         "command": ["bash-language-server", "start"],

--- a/user/.dotfiles/config/kilo/lsp.json
+++ b/user/.dotfiles/config/kilo/lsp.json
@@ -1,0 +1,58 @@
+{
+    "powershell": {
+        "command": [
+            "pwsh", "-NoLogo", "-NoProfile", "-Command",
+            "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+        ],
+        "extensions": [".ps1", ".psm1", ".psd1"]
+    },
+    "basedpyright": {
+        "command": ["basedpyright-langserver", "--stdio"],
+        "extensions": [".py", ".pyw", ".pyi"]
+    },
+    "ty": {
+        "command": ["ty", "server"],
+        "extensions": [".py", ".pyi", ".pyw"]
+    },
+    "vtsls": {
+        "command": ["vtsls", "--stdio"],
+        "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"],
+        "initialization": { "preferences": { "importModuleSpecifierPreference": "relative" } }
+    },
+    "eslint": {
+        "command": ["vscode-eslint-language-server", "--stdio"],
+        "extensions": [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".vue", ".svelte", ".astro"]
+    },
+    "html-ls": {
+        "command": ["vscode-html-language-server", "--stdio"],
+        "extensions": [".html", ".htm"]
+    },
+    "css-ls": {
+        "command": ["vscode-css-language-server", "--stdio"],
+        "extensions": [".css", ".scss", ".less", ".sass"]
+    },
+    "bash": {
+        "command": ["bash-language-server", "start"],
+        "extensions": [".sh", ".bash", ".zsh", ".ksh"]
+    },
+    "yaml-ls": {
+        "command": ["yaml-language-server", "--stdio"],
+        "extensions": [".yaml", ".yml"]
+    },
+    "json-ls": {
+        "command": ["vscode-json-language-server", "--stdio"],
+        "extensions": [".json", ".jsonc"]
+    },
+    "rust": {
+        "command": ["rust-analyzer"],
+        "extensions": [".rs"]
+    },
+    "tombi": {
+        "command": ["tombi", "lsp"],
+        "extensions": [".toml"]
+    },
+    "dockerfile-ls": {
+        "command": ["docker-langserver", "--stdio"],
+        "extensions": [".dockerfile"]
+    }
+}

--- a/user/.dotfiles/config/opencode/lsp.json
+++ b/user/.dotfiles/config/opencode/lsp.json
@@ -60,7 +60,9 @@
             ".js": "javascript",
             ".jsx": "javascriptreact",
             ".mjs": "javascript",
-            ".cjs": "javascript"
+            ".cjs": "javascript",
+            ".mts": "typescript",
+            ".cts": "typescript"
         },
         "transport": "stdio",
         "initializationOptions": {},

--- a/user/.dotfiles/config/opencode/lsp.json
+++ b/user/.dotfiles/config/opencode/lsp.json
@@ -1,0 +1,176 @@
+{
+    "powershell": {
+        "command": "pwsh",
+        "args": [
+            "-NoLogo",
+            "-NoProfile",
+            "-Command",
+            "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+        ],
+        "extensionToLanguage": {
+            ".ps1": "powershell",
+            ".psm1": "powershell",
+            ".psd1": "powershell"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "startupTimeout": 120000,
+        "shutdownTimeout": 20000,
+        "maxRestarts": 3
+    },
+    "basedpyright": {
+        "command": "basedpyright-langserver",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "ty": {
+        "command": "ty",
+        "args": [
+            "server"
+        ],
+        "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "typescript": {
+        "command": "vtsls",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "html": {
+        "command": "vscode-html-language-server",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".html": "html",
+            ".htm": "html"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "css": {
+        "command": "vscode-css-language-server",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".css": "css",
+            ".scss": "scss",
+            ".sass": "sass",
+            ".less": "less"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "eslint": {
+        "command": "vscode-eslint-language-server",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".vue": "vue",
+            ".svelte": "svelte",
+            ".astro": "astro"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {
+            "validate": "on",
+            "useESLintClass": true,
+            "run": "onType",
+            "format": false,
+            "quiet": false,
+            "onIgnoredFiles": "off",
+            "codeAction": {
+                "disableRuleComment": {
+                    "enable": true,
+                    "location": "separateLine"
+                },
+                "showDocumentation": {
+                    "enable": true
+                }
+            },
+            "codeActionOnSave": {
+                "mode": "all"
+            },
+            "problems": {
+                "shortenToSingleLine": false
+            },
+            "workingDirectory": {
+                "mode": "location"
+            }
+        },
+        "maxRestarts": 3
+    },
+    "bash": {
+        "command": "bash-language-server",
+        "args": [
+            "start"
+        ],
+        "extensionToLanguage": {
+            ".sh": "shellscript",
+            ".bash": "shellscript",
+            ".zsh": "shellscript",
+            ".ksh": "shellscript"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "yaml": {
+        "command": "yaml-language-server",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".yaml": "yaml",
+            ".yml": "yaml"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}


### PR DESCRIPTION
## Summary
Add Language Server Protocol (LSP) configuration files for two editor environments: OpenCode and Kilo. These configurations enable IDE-like features (code completion, diagnostics, formatting) across multiple programming languages.

## Changes

- **`user/.dotfiles/config/opencode/lsp.json`** (new)
  - Comprehensive LSP server configuration for OpenCode editor
  - Supports 9 language servers: PowerShell, Python (basedpyright + ty), TypeScript/JavaScript (vtsls), HTML, CSS, ESLint, Bash, and YAML
  - Each server includes command, file extension mappings, transport protocol, and timeout settings
  - ESLint configuration includes detailed settings for validation, code actions, and problem reporting

- **`user/.dotfiles/config/kilo/lsp.json`** (new)
  - Streamlined LSP configuration for Kilo editor
  - Supports 13 language servers with a more compact format (command arrays, extensions lists)
  - Includes additional servers not in OpenCode: JSON, Rust (rust-analyzer), TOML (tombi), and Dockerfile
  - Vtsls includes initialization preferences for relative import module specifiers

- **`.kilo/kilo.json`** (modified)
  - Added `.ksh` (Korn shell) extension to bash language server
  - Added `ty` Python language server configuration
  - Added ESLint language server configuration
  - Maintains consistency with new Kilo LSP configuration file

## Implementation Details

- Both configurations use stdio transport for language server communication
- PowerShell server includes complex initialization logic to locate and load PowerShellEditorServices module
- OpenCode format uses separate `extensionToLanguage` mappings; Kilo uses simpler `extensions` arrays
- All servers configured with `maxRestarts: 3` for resilience
- Timeouts set appropriately (PowerShell: 120s startup, 20s shutdown; others use defaults)

https://claude.ai/code/session_018dHpuKfKz4jxtHeRnNiYAX