### PR TITLE
🧹 [code health] Remove unused parameter $Complete from Show-Progress

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -547,8 +547,7 @@ function Get-FileFromWeb {
             [Parameter(Mandatory)][Single]$TotalValue,
             [Parameter(Mandatory)][Single]$CurrentValue,
             [Parameter(Mandatory)][string]$ProgressText,
-            [Parameter()][int]$BarSize = 10,
-            [Parameter()][switch]$Complete
+            [Parameter()][int]$BarSize = 10
         )
 
         $percent = $CurrentValue / $TotalValue


### PR DESCRIPTION
🎯 **What:** Removed the unused `[switch]$Complete` parameter from the nested `Show-Progress` function in `Scripts/Common.ps1`.
💡 **Why:** The parameter was defined but never used in the function's logic, which improves code maintainability and reduces clutter.
✅ **Verification:** Verified that the function logic remains intact through standalone PowerShell test scripts and confirmed that `Get-FileFromWeb` still parses correctly.
✨ **Result:** Cleaner code and resolved a potential linting warning for unused parameters.

---
*PR created automatically by Jules for task [14579391344135397278](https://jules.google.com/task/14579391344135397278) started by @Ven0m0*