### PR TITLE
🧹 Refactor Get-WmiObject to Get-CimInstance in Get-MonitorInstance

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -630,7 +630,7 @@ function Get-MonitorInstance {
 
     if ($ForceRefresh -or -not $script:CachedMonitorInstances) {
         try {
-            $script:CachedMonitorInstances = (Get-WmiObject -Namespace root\wmi -Class WmiMonitorID `
+            $script:CachedMonitorInstances = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorID `
                 -ErrorAction Stop).InstanceName -replace '_0', ''
         } catch {
             Write-ColorOutput "Error retrieving monitor information: $($_.Exception.Message)" -ForegroundColor Red


### PR DESCRIPTION
🎯 **What:** Replaced the deprecated `Get-WmiObject` cmdlet with `Get-CimInstance` in the `Get-MonitorInstance` function within `Scripts/Common.ps1`.
💡 **Why:** `Get-WmiObject` is deprecated and native cmdlets like `Get-CimInstance` should be preferred. `Get-CimInstance` works over WinRM on both PowerShell 5.1 and 7+ and provides a cleaner, more modern approach to interacting with WMI/CIM classes.
✅ **Verification:** Ran `Invoke-Pester -Path ./tests/Common.Tests.ps1`. The file `Common.ps1` maintains its UTF-8 BOM encoding.
✨ **Result:** Improved codebase health and modernization without modifying functionality.

---
*PR created automatically by Jules for task [2514233910575496203](https://jules.google.com/task/2514233910575496203) started by @Ven0m0*