### PR TITLE
🧪 Add tests for Clear-PathSafe in Common.ps1

### DIFF
--- a/tests/Common.Tests.ps1
+++ b/tests/Common.Tests.ps1
@@ -407,8 +407,12 @@ Describe "Clear-PathSafe" {
 
         Clear-PathSafe -Path "C:\Temp\MyFolder"
 
-        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" -and (-not $PathType) }
-        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" -and $PathType -eq 'Container' }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\MyFolder" -and (-not $PathType)
+        }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\MyFolder" -and $PathType -eq 'Container'
+        }
         Should -Invoke -CommandName Clear-DirectorySafe -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" }
         Should -Invoke -CommandName Remove-Item -Times 0
     }
@@ -423,8 +427,12 @@ Describe "Clear-PathSafe" {
 
         Clear-PathSafe -Path "C:\Temp\MyFile.txt"
 
-        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFile.txt" -and (-not $PathType) }
-        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFile.txt" -and $PathType -eq 'Container' }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\MyFile.txt" -and (-not $PathType)
+        }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\MyFile.txt" -and $PathType -eq 'Container'
+        }
         Should -Invoke -CommandName Remove-Item -Times 1 -ParameterFilter {
             $Path -eq "C:\Temp\MyFile.txt" -and $Force
         }

--- a/tests/Common.Tests.ps1
+++ b/tests/Common.Tests.ps1
@@ -373,3 +373,61 @@ Describe "Get-FolderSize" {
         $result | Should -Be 2
     }
 }
+
+Describe "Clear-PathSafe" {
+    It "Should use Remove-Item with Recurse for wildcard paths" {
+        Mock Remove-Item { }
+
+        Clear-PathSafe -Path "C:\Temp\*"
+
+        Should -Invoke -CommandName Remove-Item -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\*" -and $Recurse -and $Force
+        }
+    }
+
+    It "Should do nothing if non-wildcard path does not exist" {
+        Mock Test-Path { return $false }
+        Mock Remove-Item { }
+        Mock Clear-DirectorySafe { }
+
+        Clear-PathSafe -Path "C:\Temp\NonExistent"
+
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\NonExistent" }
+        Should -Invoke -CommandName Remove-Item -Times 0
+        Should -Invoke -CommandName Clear-DirectorySafe -Times 0
+    }
+
+    It "Should call Clear-DirectorySafe for directories" {
+        Mock Test-Path {
+            if ($PathType -eq 'Container') { return $true }
+            return $true
+        }
+        Mock Clear-DirectorySafe { }
+        Mock Remove-Item { }
+
+        Clear-PathSafe -Path "C:\Temp\MyFolder"
+
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" -and (-not $PathType) }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" -and $PathType -eq 'Container' }
+        Should -Invoke -CommandName Clear-DirectorySafe -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFolder" }
+        Should -Invoke -CommandName Remove-Item -Times 0
+    }
+
+    It "Should use Remove-Item without Recurse for single files" {
+        Mock Test-Path {
+            if ($PathType -eq 'Container') { return $false }
+            return $true
+        }
+        Mock Remove-Item { }
+        Mock Clear-DirectorySafe { }
+
+        Clear-PathSafe -Path "C:\Temp\MyFile.txt"
+
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFile.txt" -and (-not $PathType) }
+        Should -Invoke -CommandName Test-Path -Times 1 -ParameterFilter { $Path -eq "C:\Temp\MyFile.txt" -and $PathType -eq 'Container' }
+        Should -Invoke -CommandName Remove-Item -Times 1 -ParameterFilter {
+            $Path -eq "C:\Temp\MyFile.txt" -and $Force
+        }
+        Should -Invoke -CommandName Clear-DirectorySafe -Times 0
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `Clear-PathSafe` (Common.ps1) has been addressed.
📊 **Coverage:** Scenarios for wildcard paths, non-existent paths, directories, and single files are now tested via Pester mocks for `Remove-Item`, `Clear-DirectorySafe`, and `Test-Path`.
✨ **Result:** Increased test coverage and ensured that the proper deletion strategies are chosen safely based on the type of path.

---
*PR created automatically by Jules for task [1188755014113003065](https://jules.google.com/task/1188755014113003065) started by @Ven0m0*