### PR TITLE
Fix broken QoS commands in priority.ps1 by switching to Registry implementation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -113,7 +113,7 @@ Scripts with no Pester tests:
 - [x] `#Requires -Version 5.1` present on all root-level scripts
 - [ ] Network-Tweaker.ps1 PSScriptAnalyzer clean
 - [ ] enable-timer-res.ps1 hardcoded path replaced
-- [ ] reg/priority.ps1 QoS TODO resolved
+- [x] reg/priority.ps1 QoS TODO resolved
 - [ ] Notepad Replacer added to package installation
 - [ ] Steam VDF consolidation complete
 - [ ] Test coverage added for New-SteamShortcut, Optimize-Steam, Steam-Config, enable-timer-res

--- a/Scripts/reg/priority.ps1
+++ b/Scripts/reg/priority.ps1
@@ -1,10 +1,43 @@
 ﻿#Requires -Version 5.1
 #Requires -RunAsAdministrator
 
-# === QoS PowerShell equivalent === TODO: fix broken Qos commands
-New-NetQosPolicy -Name "ArcRaiders" -AppPathNameMatchCondition "PioneerGame.exe" -DSCPAction 46
-New-NetQosPolicy -Name "BlackOps6" -AppPathNameMatchCondition "cod24-cod.exe" -DSCPAction 46
-New-NetQosPolicy -Name "Fortnite" -AppPathNameMatchCondition "FortniteClient-Win64-Shipping.exe" -DSCPAction 46
+# === QoS Registry Implementation (Home/Pro compatible) ===
+$qosPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\QoS'
+if (-not (Test-Path -Path $qosPath)) {
+    New-Item -Path $qosPath -Force | Out-Null
+}
+
+$qosGames = @{
+    'ArcRaiders' = 'PioneerGame.exe'
+    'BlackOps6'  = 'cod24-cod.exe'
+    'Fortnite'   = 'FortniteClient-Win64-Shipping.exe'
+}
+
+foreach ($game in $qosGames.GetEnumerator()) {
+    $gamePath = Join-Path -Path $qosPath -ChildPath $game.Name
+    if (-not (Test-Path -Path $gamePath)) {
+        New-Item -Path $gamePath -Force | Out-Null
+    }
+
+    $props = @{
+        'Version'                 = '1.0'
+        'Application Name'        = $game.Value
+        'Protocol'                = '*'
+        'Local Port'              = '*'
+        'Remote Port'             = '*'
+        'Local IP'                = '*'
+        'Remote IP'               = '*'
+        'Local IP Prefix Length'  = '*'
+        'Remote IP Prefix Length' = '*'
+        'DSCP Value'              = '46'
+        'Throttle Rate'           = '-1'
+    }
+
+    foreach ($prop in $props.GetEnumerator()) {
+        Set-ItemProperty -Path $gamePath -Name $prop.Name -Value $prop.Value -Type String | Out-Null
+    }
+}
+
 gpupdate /force
 
 # === Windows Defender Exclusions ===

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 ### Script Quality
 - [ ] Verify `Scripts/Network-Tweaker.ps1` for remaining PSScriptAnalyzer issues (4,233 lines — needs full lint run)
 - [ ] Fix `Scripts/enable-timer-res.ps1` hardcoded `C:\SetTimerResolution.exe` path → use `$env:SystemDrive`
-- [ ] Fix `Scripts/reg/priority.ps1` line 4 TODO: broken QoS `netsh` commands need replacement
+- [x] Fix `Scripts/reg/priority.ps1` line 4 TODO: broken QoS `netsh` commands need replacement
 
 ### Test Coverage (no Pester tests exist)
 - [ ] `tests/New-SteamShortcut.Tests.ps1`


### PR DESCRIPTION
The QoS commands using `New-NetQosPolicy` in `Scripts/reg/priority.ps1` were failing because the `NetQos` module and cmdlets are not supported on Windows 10/11 Home editions (and generate "operation is not supported" errors).

This patch refactors the script to bypass the cmdlet entirely, creating the exact equivalent QoS DSCP policies directly within the Windows Registry at `HKLM:\SOFTWARE\Policies\Microsoft\Windows\QoS`. This approach produces the same results and works natively across both Home and Pro editions.

Additionally, updated `TODO.md` and `PLAN.md` to reflect the completed state.

---
*PR created automatically by Jules for task [6455257681025332233](https://jules.google.com/task/6455257681025332233) started by @Ven0m0*