### PR TITLE
🧹 Remove unused variable suppression in Initialize-ConsoleUI

### DIFF
--- a/Scripts/Common.ps1
+++ b/Scripts/Common.ps1
@@ -66,12 +66,8 @@ function Initialize-ConsoleUI {
         The window title to set
     #>
     param(
-        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Title')]
         [string]$Title = $myInvocation.MyCommand.Definition + " (Administrator)"
     )
-
-    # Use parameter to prevent unused variable warnings while maintaining backward compatibility
-    $null = $Title
     try { $Host.UI.RawUI.WindowTitle = $Title } catch { Write-Verbose "WindowTitle not supported on this host: $_" }
     $Host.UI.RawUI.BackgroundColor = "Black"
     $Host.PrivateData.ProgressBackgroundColor = "Black"


### PR DESCRIPTION
🎯 **What:** Removed the `[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Title')]` and `$null = $Title` lines from the `Initialize-ConsoleUI` function in `Scripts/Common.ps1`.
💡 **Why:** The parameter `$Title` is actually used in the function (`$Host.UI.RawUI.WindowTitle = $Title`), so the suppression and the assignment to `$null` to "maintain backward compatibility" were incorrect and misleading. Removing them improves code readability.
✅ **Verification:** Ran `Invoke-ScriptAnalyzer` which showed no unused parameter warning for `$Title`, and ran the full Pester test suite to ensure no regressions were introduced.
✨ **Result:** Cleaner code without unnecessary parameter suppression.

---
*PR created automatically by Jules for task [15818213209866296943](https://jules.google.com/task/15818213209866296943) started by @Ven0m0*