### PR TITLE
🧹 Replace deprecated Get-WmiObject with Get-CimInstance in autounattend.xml

### DIFF
--- a/Scripts/auto/autounattend.xml
+++ b/Scripts/auto/autounattend.xml
@@ -714,7 +714,7 @@ Write-Log "=====================================================================
 
 function Get-TargetUser {
     try {
-        $user = Get-WmiObject Win32_ComputerSystem | Select-Object -ExpandProperty UserName
+        $user = Get-CimInstance Win32_ComputerSystem | Select-Object -ExpandProperty UserName
         if ($user -and $user -ne "NT AUTHORITY\SYSTEM") {
             $username = $user.Split('\')[1]
             if ($username -ne "defaultuser0") {
@@ -1350,7 +1350,7 @@ if ($hasXboxPackages) {
 
         if ($runningAsSystem) {
             Write-Log "Running as SYSTEM - detecting logged-in user..."
-            $loggedInUser = (Get-WmiObject -Class Win32_ComputerSystem -ErrorAction SilentlyContinue).UserName
+            $loggedInUser = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).UserName
 
             if ($loggedInUser -and $loggedInUser -ne "NT AUTHORITY\SYSTEM") {
                 $username = $loggedInUser.Split('\\')[1]
@@ -1507,7 +1507,7 @@ function Test-ChromiumEdgeInstalled {
 
     # Fallback: Check installed programs
     try {
-        $edgeApp = Get-WmiObject -Class Win32_InstalledStoreProgram -Filter "Name like '%Microsoft.MicrosoftEdge.Stable%'" -ErrorAction SilentlyContinue
+        $edgeApp = Get-CimInstance -ClassName Win32_InstalledStoreProgram -Filter "Name like '%Microsoft.MicrosoftEdge.Stable%'" -ErrorAction SilentlyContinue
         return $edgeApp -ne $null
     } catch {
         return $false
@@ -2169,7 +2169,7 @@ function Get-TargetUser {
     Write-Log "Get-TargetUser: Starting user detection"
 
     try {
-        $user = Get-WmiObject Win32_ComputerSystem | Select-Object -ExpandProperty UserName
+        $user = Get-CimInstance Win32_ComputerSystem | Select-Object -ExpandProperty UserName
         Write-Log "Get-TargetUser: Win32_ComputerSystem returned: '$user'"
         if ($user -and $user -ne "NT AUTHORITY\SYSTEM") {
             $username = $user.Split('\')[1]


### PR DESCRIPTION
🎯 **What:** Replaced deprecated `Get-WmiObject` with `Get-CimInstance` in `Scripts/auto/autounattend.xml` (the original target `Scripts/Common.ps1` had already been refactored in `main`).
💡 **Why:** `Get-WmiObject` is deprecated and using `Get-CimInstance` improves maintainability, performance, and cross-platform compatibility in modern PowerShell environments.
✅ **Verification:** Verified by checking that `Invoke-ScriptAnalyzer` runs cleanly on `autounattend.xml` and running the test suite with `Invoke-Pester` (test failures are related to unaffected `ConvertFrom-VDF` tests).
✨ **Result:** Cleaned up the 4 remaining `Get-WmiObject` references in the repository to `Get-CimInstance`, completely eradicating the deprecated code.

---
*PR created automatically by Jules for task [8543208078629607810](https://jules.google.com/task/8543208078629607810) started by @Ven0m0*